### PR TITLE
Bugfixes for 3.1: Join toast, Test Filters, footer theme

### DIFF
--- a/.cursor/rules/finish-the-whole-request.mdc
+++ b/.cursor/rules/finish-the-whole-request.mdc
@@ -1,0 +1,26 @@
+---
+description: Finish the whole request. Do not ship the smallest reply and wait to be told the rest.
+alwaysApply: true
+---
+
+# Finish the whole request
+
+The failure mode is **doing the smallest thing that answers the last message**, then waiting for the user to find the rest.
+
+If you are about to write generic bullets and call that done, stop. Do the actual class of work, all the way through.
+
+## What complete means
+
+- A feature follows the patterns already in the project. Do not invent a parallel coordinator, a wrapper type, or a placeholder “for now.”
+- UI matches existing screens: spacing, titles, toolbar, close control, button styles. Propose source-language copy first; do not translate a draft.
+- After two failures on a side quest, say so and offer to drop it. Do not keep generating files.
+- Fix the path they named. If they gave an order of operations, that order is the spec. Tests before more conditionals.
+- Cleanup means hunt. Grep what they killed. Delete the file. Remove unused strings. Do not leave leftovers for them to find.
+- “Don’t touch code” means don’t. No tiny follow-up. If tools wrote bytes, say which files. Finish or revert.
+- Review findings must be real. If the user cannot physically do two things at once, it is not a race. Do not flag existing product behavior as a new bug.
+- Small asks stay small. Diagrams are mermaid or ASCII, not a generated image.
+
+## Also
+
+- Obey the last standing order at every call site, not just the one you touched.
+- Explain like they are looking at the phone, not at a framework story.

--- a/.cursor/rules/pin-regressions-to-a-change.mdc
+++ b/.cursor/rules/pin-regressions-to-a-change.mdc
@@ -1,0 +1,22 @@
+---
+description: Do not guess at regressions. Find the commit that broke working behavior, then fix that.
+alwaysApply: true
+---
+
+# Pin regressions to a recent change
+
+If something **used to work** and then stopped, do not invent a new architecture or a vague framework theory and start rewriting.
+
+## Do this instead
+
+1. Treat “it worked, then it didn’t” as a **regression**, not a missing feature.
+2. Find when it last worked (`git log` / `git blame` on the path that used to work).
+3. Diff **that path** from the last good commit to `HEAD`. Name the commit that changed behavior.
+4. Fix **that** change. Leave the old working structure alone unless the diff proves it is the problem.
+5. Tell the user the breaking commit and what it did, in plain words. No jargon.
+
+## Never do
+
+- Rewrite unrelated handling because a tap, gesture, or theme “might” be the cause.
+- Ship a speculative fix and only look at history after being called out.
+- Explain the bug with acronyms or framework trivia the user did not ask for.

--- a/Simply Filter SMS.xcodeproj/project.pbxproj
+++ b/Simply Filter SMS.xcodeproj/project.pbxproj
@@ -1138,7 +1138,7 @@
 				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
 				CODE_SIGN_ENTITLEMENTS = "Reporting Extension/Reporting Extension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 202608220100;
+				CURRENT_PROJECT_VERSION = 202608222346;
 				DEVELOPMENT_TEAM = AL28LDR9PU;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Reporting Extension/Info.plist";
@@ -1359,7 +1359,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Simply Filter SMS/Resources/Simply Filter SMS.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 202608220100;
+				CURRENT_PROJECT_VERSION = 202608222346;
 				DEVELOPMENT_ASSET_PATHS = "\"Simply Filter SMS/Resources/Preview Content\"";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = AL28LDR9PU;
 				ENABLE_PREVIEWS = YES;
@@ -1398,7 +1398,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Simply Filter SMS/Resources/Simply Filter SMS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 202608220100;
+				CURRENT_PROJECT_VERSION = 202608222346;
 				DEVELOPMENT_ASSET_PATHS = "\"Simply Filter SMS/Resources/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1432,7 +1432,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Message Filter Extension/Simply Filter SMS Extension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 202608220100;
+				CURRENT_PROJECT_VERSION = 202608222346;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Message Filter Extension/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Simply Filter SMS Extension";
@@ -1458,7 +1458,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Message Filter Extension/Simply Filter SMS Extension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 202608220100;
+				CURRENT_PROJECT_VERSION = 202608222346;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Message Filter Extension/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Simply Filter SMS Extension";
@@ -1485,7 +1485,7 @@
 				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
 				CODE_SIGN_ENTITLEMENTS = "Reporting Extension/Reporting Extension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 202608220100;
+				CURRENT_PROJECT_VERSION = 202608222346;
 				DEVELOPMENT_TEAM = AL28LDR9PU;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Reporting Extension/Info.plist";

--- a/Simply Filter SMS/View Layer/Others/FooterView.swift
+++ b/Simply Filter SMS/View Layer/Others/FooterView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct FooterView: View {
     var onTap: (() ->())? = nil
-    @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
         VStack(spacing: 0) {
@@ -39,6 +38,8 @@ struct FooterView: View {
 }
 
 private struct FooterBackground: ViewModifier {
+    @Environment(\.colorScheme) private var colorScheme
+
     func body(content: Content) -> some View {
         if #available(iOS 26.0, *) {
             content
@@ -46,11 +47,13 @@ private struct FooterBackground: ViewModifier {
                     Color.clear
                         .glassEffect(.regular, in: .rect(cornerRadius: 0))
                         .ignoresSafeArea(.container, edges: .bottom)
+                        .id(colorScheme)
                 }
         } else {
             content
                 .background(.ultraThinMaterial)
                 .ignoresSafeArea(.container, edges: .bottom)
+                .id(colorScheme)
         }
     }
 }

--- a/Simply Filter SMS/View Layer/Others/NotificationView.swift
+++ b/Simply Filter SMS/View Layer/Others/NotificationView.swift
@@ -309,7 +309,7 @@ private struct NotificationGlassBackground: ViewModifier {
     func body(content: Content) -> some View {
         if #available(iOS 26.0, *) {
             content
-                .glassEffect(.clear.interactive(), in: shape)
+                .glassEffect(.clear, in: shape)
                 .containerShape(shape)
         } else {
             content
@@ -323,6 +323,7 @@ private struct NotificationActionChipBackground: ViewModifier {
     func body(content: Content) -> some View {
         if #available(iOS 26.0, *) {
             content
+                .contentShape(Capsule())
         } else {
             content
                 .contentShape(RoundedRectangle(cornerRadius: 24, style: .continuous))

--- a/Simply Filter SMS/View Layer/Others/ViewModfiers.swift
+++ b/Simply Filter SMS/View Layer/Others/ViewModfiers.swift
@@ -9,15 +9,18 @@ import SwiftUI
 
 
 struct EmbeddedFooterView: ViewModifier {
+    var isHidden: Bool = false
     var onTap: (() ->())? = nil
     
     func body(content: Content) -> some View {
         ZStack (alignment: .bottom) {
             content
                 .accessibilitySortPriority(1)
-            FooterView(onTap: onTap)
-                .ignoresSafeArea(.keyboard, edges: .all)
-                .allowsHitTesting(!ProcessInfo.processInfo.isInTestingMode)
+            if !isHidden {
+                FooterView(onTap: onTap)
+                    .ignoresSafeArea(.keyboard, edges: .all)
+                    .allowsHitTesting(!ProcessInfo.processInfo.isInTestingMode)
+            }
         }
     }
 }

--- a/Simply Filter SMS/View Layer/Screens/AppHomeView.swift
+++ b/Simply Filter SMS/View Layer/Screens/AppHomeView.swift
@@ -280,7 +280,7 @@ struct AppHomeView: View {
                     .background(Color.listBackgroundColor(for: colorScheme))
             }
         } // NavigationSplitView
-        .modifier(EmbeddedFooterView {
+        .modifier(EmbeddedFooterView(isHidden: self.model.sheetScreen != nil) {
             guard horizontalSizeClass == .regular || self.model.navigationScreen == nil else { return }
             self.model.requestSheet(.about)
         })

--- a/Simply Filter SMS/View Layer/Screens/TestFiltersView.swift
+++ b/Simply Filter SMS/View Layer/Screens/TestFiltersView.swift
@@ -58,6 +58,7 @@ struct TestFiltersView: View {
                                 .accessibilityHidden(true)
 
                             TextEditor(text: $model.text)
+                                .scrollContentBackground(.hidden)
                                 .frame(minHeight: 80, idealHeight: 80, alignment: .top)
                                 .focused($focusedField, equals: .text)
                                 .multilineTextAlignment(.leading)


### PR DESCRIPTION
## Summary
- Join on the AI filtering toast works again (banner glass was stealing the tap; chip has a hit target).
- Test Your Filters message field no longer draws a black box in Dark Mode.
- Home footer no longer stays on the old Light/Dark look after opening Test Your Filters (it is hidden while a sheet is up and rebuilds when the theme changes).
- Agent rules for regressions and finishing the whole request; build number `202608222346`.

## Test plan
- [x] Session where the AI filtering toast appears: tap Join and confirm the reporting-extension guide opens.
- [x] Test Your Filters in Dark Mode: message field matches the card, not a black inset.
- [x] Open Test Your Filters (keyboard up), close it, switch Light/Dark: footer matches the new theme.
- [x] Same theme switch without opening Test Your Filters: footer still updates.
- [x] Light Mode Test Your Filters and toast Join still look and work as before.


Made with [Cursor](https://cursor.com)