### PR TITLE
Bugfixes for 3.1.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Three-layer clean architecture with protocol-based dependency injection:
 - **PersistanceManager** — CoreData CRUD operations for `Filter`, `AutomaticFiltersRule`, `AutomaticFiltersLanguage` entities.
 - **AutomaticFilterManager** — Fetches community filter lists from S3, applies automatic rules (block links, numbers-only senders, short senders, emails, emojis, all unknown, country allowlist). S3 fetch completions hop to the MainActor before Core Data cache writes.
 - **DefaultsManager** — UserDefaults wrapper for app settings. Custom accent is `@StoredDefault("accentColorRGB", defaultValue: kNoColorDict)`.
-- **NetworkSyncManager** — NWPathMonitor + CloudKit sync status tracking (setup retries; pending retry cancelled if network recovery reloads first).
+- **NetworkSyncManager** — NWPathMonitor + CloudKit sync status tracking (setup retries; pending retry cancelled if network recovery reloads first). `reloadContainer()` posts `.persistentStoreReloaded`; screens use `.modifier(persistentStoreReload)`.
 - **TipJarManager** — StoreKit 2 in-app purchase manager for consumable tip jar products.
 - **FilterTransferManager** — Merge-only filter import/export (`.sfsfilters`). Holds one in-flight picker (`pendingPreview` / `pendingKind`); Home presents `.filterImport` or `.filterExport`. Writes/deletes export files in the temp directory.
 - **FlowManager** — Launch-order queue (not a navigator). Occupancy: `next()` sets `activeScreen`; further `next()` is nil until `complete`. Order: first run → launch (file/deep link) → automatic What's New → user `request`.

--- a/Simply Filter SMS.xcodeproj/project.pbxproj
+++ b/Simply Filter SMS.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		698322832F50AD35008FFD1D /* XCUIElementExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 698322822F50AD2C008FFD1D /* XCUIElementExtensions.swift */; };
 		6987D7FF27AACA9100B3DB84 /* mock_MessageEvaluationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6987D7FE27AACA9100B3DB84 /* mock_MessageEvaluationManager.swift */; };
 		6987D80227AAD9E400B3DB84 /* ViewModfiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6987D80127AAD9E400B3DB84 /* ViewModfiers.swift */; };
+		A24PSR0FILE0001B0000001 /* PersistentStoreReload.swift in Sources */ = {isa = PBXBuildFile; fileRef = A24PSR0FILE0001F0000001 /* PersistentStoreReload.swift */; };
 		698FBAFE27B44A0700435699 /* NetworkSyncManagerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 698FBAFD27B44A0700435699 /* NetworkSyncManagerProtocol.swift */; };
 		698FBB0027B4629800435699 /* mock_NetworkSyncManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 698FBAFF27B4629800435699 /* mock_NetworkSyncManager.swift */; };
 		699F55802778BB3100AD7C64 /* AddFilterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 699F557F2778BB3100AD7C64 /* AddFilterView.swift */; };
@@ -271,6 +272,7 @@
 		698322822F50AD2C008FFD1D /* XCUIElementExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCUIElementExtensions.swift; sourceTree = "<group>"; };
 		6987D7FE27AACA9100B3DB84 /* mock_MessageEvaluationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = mock_MessageEvaluationManager.swift; sourceTree = "<group>"; };
 		6987D80127AAD9E400B3DB84 /* ViewModfiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModfiers.swift; sourceTree = "<group>"; };
+		A24PSR0FILE0001F0000001 /* PersistentStoreReload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistentStoreReload.swift; sourceTree = "<group>"; };
 		698FBAFD27B44A0700435699 /* NetworkSyncManagerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkSyncManagerProtocol.swift; sourceTree = "<group>"; };
 		698FBAFF27B4629800435699 /* mock_NetworkSyncManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = mock_NetworkSyncManager.swift; sourceTree = "<group>"; };
 		699F557F2778BB3100AD7C64 /* AddFilterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddFilterView.swift; sourceTree = "<group>"; };
@@ -667,6 +669,7 @@
 				690F09C427AC22CD00BA481F /* BaseViewModel.swift */,
 				690F054D278200B60036553B /* ButtonStyles.swift */,
 				6987D80127AAD9E400B3DB84 /* ViewModfiers.swift */,
+				A24PSR0FILE0001F0000001 /* PersistentStoreReload.swift */,
 				BF981F0B1B564B22AF8F9F0D /* ConfettiView.swift */,
 				6941FE1B277FDBE700B99539 /* MailView.swift */,
 				A1B2C3D4E5F60718293A0006 /* ShareSheet.swift */,
@@ -1014,6 +1017,7 @@
 				69B2A9AB279CD964000DFAFC /* PersistanceManager.swift in Sources */,
 				69F4096F27B948D800749552 /* AutomaticFilterListsResponse.swift in Sources */,
 				6987D80227AAD9E400B3DB84 /* ViewModfiers.swift in Sources */,
+				A24PSR0FILE0001B0000001 /* PersistentStoreReload.swift in Sources */,
 				698FBAFE27B44A0700435699 /* NetworkSyncManagerProtocol.swift in Sources */,
 				69CD70D62770D4D100F91A2F /* Simply-Filter-SMS.xcdatamodeld in Sources */,
 				690D709C27B31DC0001880DA /* NotificationView.swift in Sources */,

--- a/Simply Filter SMS.xcodeproj/project.pbxproj
+++ b/Simply Filter SMS.xcodeproj/project.pbxproj
@@ -67,7 +67,6 @@
 		698322832F50AD35008FFD1D /* XCUIElementExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 698322822F50AD2C008FFD1D /* XCUIElementExtensions.swift */; };
 		6987D7FF27AACA9100B3DB84 /* mock_MessageEvaluationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6987D7FE27AACA9100B3DB84 /* mock_MessageEvaluationManager.swift */; };
 		6987D80227AAD9E400B3DB84 /* ViewModfiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6987D80127AAD9E400B3DB84 /* ViewModfiers.swift */; };
-		A24PSR0FILE0001B0000001 /* PersistentStoreReload.swift in Sources */ = {isa = PBXBuildFile; fileRef = A24PSR0FILE0001F0000001 /* PersistentStoreReload.swift */; };
 		698FBAFE27B44A0700435699 /* NetworkSyncManagerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 698FBAFD27B44A0700435699 /* NetworkSyncManagerProtocol.swift */; };
 		698FBB0027B4629800435699 /* mock_NetworkSyncManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 698FBAFF27B4629800435699 /* mock_NetworkSyncManager.swift */; };
 		699F55802778BB3100AD7C64 /* AddFilterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 699F557F2778BB3100AD7C64 /* AddFilterView.swift */; };
@@ -123,6 +122,7 @@
 		A1B2C3D4E5F60718293A1011 /* FlowManagerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718293A0011 /* FlowManagerProtocol.swift */; };
 		A1B2C3D4E5F60718293A1012 /* mock_FlowManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718293A0012 /* mock_FlowManager.swift */; };
 		A1B2C3D4E5F60718293A1013 /* FlowManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718293A0013 /* FlowManagerTests.swift */; };
+		A24PSR0FILE0001B0000001 /* PersistentStoreReload.swift in Sources */ = {isa = PBXBuildFile; fileRef = A24PSR0FILE0001F0000001 /* PersistentStoreReload.swift */; };
 		AA03DD65D4B6D2B613076E42 /* ReportMessageResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69ECF14B28677505000380A2 /* ReportMessageResponse.swift */; };
 		AA1B2C3D4E5F6A7B8C9D0E1F /* AddFilterViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1B2C3D4E5F6A7B8C9D0E1E /* AddFilterViewModelTests.swift */; };
 		AA4BCED7D8924F6E9A3B5C04 /* CallingCodes.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1BCED7D8924F6E9A3B5C01 /* CallingCodes.swift */; };
@@ -272,7 +272,6 @@
 		698322822F50AD2C008FFD1D /* XCUIElementExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCUIElementExtensions.swift; sourceTree = "<group>"; };
 		6987D7FE27AACA9100B3DB84 /* mock_MessageEvaluationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = mock_MessageEvaluationManager.swift; sourceTree = "<group>"; };
 		6987D80127AAD9E400B3DB84 /* ViewModfiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModfiers.swift; sourceTree = "<group>"; };
-		A24PSR0FILE0001F0000001 /* PersistentStoreReload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistentStoreReload.swift; sourceTree = "<group>"; };
 		698FBAFD27B44A0700435699 /* NetworkSyncManagerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkSyncManagerProtocol.swift; sourceTree = "<group>"; };
 		698FBAFF27B4629800435699 /* mock_NetworkSyncManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = mock_NetworkSyncManager.swift; sourceTree = "<group>"; };
 		699F557F2778BB3100AD7C64 /* AddFilterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddFilterView.swift; sourceTree = "<group>"; };
@@ -335,6 +334,7 @@
 		A1B2C3D4E5F60718293A0011 /* FlowManagerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlowManagerProtocol.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60718293A0012 /* mock_FlowManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = mock_FlowManager.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F60718293A0013 /* FlowManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlowManagerTests.swift; sourceTree = "<group>"; };
+		A24PSR0FILE0001F0000001 /* PersistentStoreReload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistentStoreReload.swift; sourceTree = "<group>"; };
 		AA001122334455667788990A /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Localizable.strings; sourceTree = "<group>"; };
 		AA001122334455667788990B /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = it; path = it.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		AA1B2C3D4E5F6A7B8C9D0E1E /* AddFilterViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddFilterViewModelTests.swift; sourceTree = "<group>"; };
@@ -1142,13 +1142,13 @@
 				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
 				CODE_SIGN_ENTITLEMENTS = "Reporting Extension/Reporting Extension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 202608222346;
+				CURRENT_PROJECT_VERSION = 202608242020;
 				DEVELOPMENT_TEAM = AL28LDR9PU;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Reporting Extension/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Simply Filter SMS Reporting Extension";
 				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
-				MARKETING_VERSION = 3.1.0;
+				MARKETING_VERSION = 3.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.grizz.apps.dev.Simply-Filter-SMS.Simply-Filter-SMS-Report-Extension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1363,7 +1363,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Simply Filter SMS/Resources/Simply Filter SMS.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 202608222346;
+				CURRENT_PROJECT_VERSION = 202608242020;
 				DEVELOPMENT_ASSET_PATHS = "\"Simply Filter SMS/Resources/Preview Content\"";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = AL28LDR9PU;
 				ENABLE_PREVIEWS = YES;
@@ -1381,7 +1381,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.1.0;
+				MARKETING_VERSION = 3.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.grizz.apps.dev.Simply-Filter-SMS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "May 22: Simply Filter SMS - Dev";
@@ -1402,7 +1402,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Simply Filter SMS/Resources/Simply Filter SMS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 202608222346;
+				CURRENT_PROJECT_VERSION = 202608242020;
 				DEVELOPMENT_ASSET_PATHS = "\"Simply Filter SMS/Resources/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1419,7 +1419,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.1.0;
+				MARKETING_VERSION = 3.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.grizz.apps.dev.Simply-Filter-SMS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1436,7 +1436,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Message Filter Extension/Simply Filter SMS Extension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 202608222346;
+				CURRENT_PROJECT_VERSION = 202608242020;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Message Filter Extension/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Simply Filter SMS Extension";
@@ -1447,7 +1447,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.1.0;
+				MARKETING_VERSION = 3.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.grizz.apps.dev.Simply-Filter-SMS.Simply-Filter-SMS-Extension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1462,7 +1462,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Message Filter Extension/Simply Filter SMS Extension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 202608222346;
+				CURRENT_PROJECT_VERSION = 202608242020;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Message Filter Extension/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Simply Filter SMS Extension";
@@ -1473,7 +1473,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.1.0;
+				MARKETING_VERSION = 3.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.grizz.apps.dev.Simply-Filter-SMS.Simply-Filter-SMS-Extension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1489,13 +1489,13 @@
 				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
 				CODE_SIGN_ENTITLEMENTS = "Reporting Extension/Reporting Extension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 202608222346;
+				CURRENT_PROJECT_VERSION = 202608242020;
 				DEVELOPMENT_TEAM = AL28LDR9PU;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Reporting Extension/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Simply Filter SMS Reporting Extension";
 				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
-				MARKETING_VERSION = 3.1.0;
+				MARKETING_VERSION = 3.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.grizz.apps.dev.Simply-Filter-SMS.Simply-Filter-SMS-Report-Extension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/Simply Filter SMS/Framework Layer/Managers/FilterTransferManager.swift
+++ b/Simply Filter SMS/Framework Layer/Managers/FilterTransferManager.swift
@@ -44,7 +44,8 @@ class FilterTransferManager: FilterTransferManagerProtocol {
         self.clearPendingExportFile()
         let preview = FilterTransferPreview(candidates: self.candidatesFromStore(),
                                           duplicateCount: 0,
-                                          invalidCount: 0)
+                                          invalidCount: 0,
+                                          forceClearTypes: [])
         self.pendingPreview = preview
         self.pendingKind = .exportFilters
         return preview
@@ -85,6 +86,7 @@ class FilterTransferManager: FilterTransferManagerProtocol {
 
     func previewImport(data: Data) throws -> FilterTransferPreview {
         let payload = try self.decodePayload(data)
+        let typesToClear = Self.forceClearTypes(from: payload)
         var accepted: [FilterTransferCandidate] = []
         var duplicateCount = 0
         var invalidCount = 0
@@ -97,11 +99,12 @@ class FilterTransferManager: FilterTransferManagerProtocol {
             }
 
             let key = candidate.duplicateKey
-            if seenKeys.contains(key) ||
+            let isStoreDuplicate = !typesToClear.contains(candidate.type) &&
                 self.persistanceManager.isDuplicateFilter(text: candidate.text,
                                                           filterTarget: candidate.filterTarget,
                                                           filterMatching: candidate.filterMatching,
-                                                          filterCase: candidate.filterCase) {
+                                                          filterCase: candidate.filterCase)
+            if seenKeys.contains(key) || isStoreDuplicate {
                 duplicateCount += 1
                 continue
             }
@@ -110,7 +113,10 @@ class FilterTransferManager: FilterTransferManagerProtocol {
             accepted.append(candidate)
         }
 
-        return FilterTransferPreview(candidates: accepted, duplicateCount: duplicateCount, invalidCount: invalidCount)
+        return FilterTransferPreview(candidates: accepted,
+                                     duplicateCount: duplicateCount,
+                                     invalidCount: invalidCount,
+                                     forceClearTypes: typesToClear)
     }
 
     func queueImport(data: Data) throws -> FilterTransferPreview {
@@ -130,6 +136,13 @@ class FilterTransferManager: FilterTransferManagerProtocol {
     }
 
     func importFilters(_ candidates: [FilterTransferCandidate]) -> FilterTransferResult {
+        for type in self.pendingPreview.forceClearTypes {
+            let existing = self.persistanceManager.fetchFilterRecords(for: type)
+            if !existing.isEmpty {
+                self.persistanceManager.deleteFilters(Set(existing))
+            }
+        }
+
         var added = 0
 
         for candidate in candidates {
@@ -162,7 +175,8 @@ class FilterTransferManager: FilterTransferManagerProtocol {
                                           version: FilterExportPayload.currentVersion,
                                           exportedAt: Date(),
                                           appVersion: appVersion,
-                                          filters: records)
+                                          filters: records,
+                                          forceClearBeforeImport: nil)
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         encoder.dateEncodingStrategy = .iso8601
@@ -223,6 +237,10 @@ class FilterTransferManager: FilterTransferManagerProtocol {
         } catch {
             throw FilterTransferError.invalidFile
         }
+    }
+
+    private static func forceClearTypes(from payload: FilterExportPayload) -> Set<FilterType> {
+        Set((payload.forceClearBeforeImport ?? []).compactMap({ FilterType(exportKey: $0) }))
     }
 
     private static func candidate(from record: FilterExportRecord) -> FilterTransferCandidate? {

--- a/Simply Filter SMS/Framework Layer/Managers/PersistanceManager.swift
+++ b/Simply Filter SMS/Framework Layer/Managers/PersistanceManager.swift
@@ -98,6 +98,11 @@ class PersistanceManager: PersistanceManagerProtocol {
             container.viewContext.mergePolicy = NSMergePolicy(merge: .overwriteMergePolicyType)
             container.viewContext.automaticallyMergesChangesFromParent = true
             container.viewContext.stalenessInterval = 0
+
+            DispatchQueue.main.async {
+                AppManager.logger.debug("reloadContainer — store loaded, posting persistentStoreReloaded")
+                NotificationCenter.default.post(name: .persistentStoreReloaded, object: nil)
+            }
         })
     }
 

--- a/Simply Filter SMS/Framework Layer/Managers/Protocols/FilterTransferManagerProtocol.swift
+++ b/Simply Filter SMS/Framework Layer/Managers/Protocols/FilterTransferManagerProtocol.swift
@@ -22,6 +22,7 @@ struct FilterExportPayload: Codable, Equatable {
     let exportedAt: Date
     let appVersion: String
     let filters: [FilterExportRecord]
+    let forceClearBeforeImport: [String]?
 }
 
 struct FilterExportRecord: Codable, Equatable {
@@ -74,11 +75,12 @@ struct FilterTransferCandidate: Equatable, Identifiable {
 }
 
 struct FilterTransferPreview: Equatable {
-    static let empty = FilterTransferPreview(candidates: [], duplicateCount: 0, invalidCount: 0)
+    static let empty = FilterTransferPreview(candidates: [], duplicateCount: 0, invalidCount: 0, forceClearTypes: [])
 
     let candidates: [FilterTransferCandidate]
     let duplicateCount: Int
     let invalidCount: Int
+    let forceClearTypes: Set<FilterType>
 
     var count: Int { return self.candidates.count }
     var skippedCount: Int { return self.duplicateCount + self.invalidCount }

--- a/Simply Filter SMS/Framework Layer/Managers/Protocols/NetworkSyncManagerProtocol.swift
+++ b/Simply Filter SMS/Framework Layer/Managers/Protocols/NetworkSyncManagerProtocol.swift
@@ -23,6 +23,7 @@ extension NSNotification.Name {
     static let automaticFiltersUpdated: NSNotification.Name = NSNotification.Name("AutomaticFiltersUpdated")
     static let onClipboardSet: NSNotification.Name = NSNotification.Name("OnClipboardSet")
     static let filtersStateChanged: NSNotification.Name = NSNotification.Name("FiltersStateChanged")
+    static let persistentStoreReloaded: NSNotification.Name = NSNotification.Name("PersistentStoreReloaded")
 }
 
 

--- a/Simply Filter SMS/Resources/ar.lproj/Localizable.strings
+++ b/Simply Filter SMS/Resources/ar.lproj/Localizable.strings
@@ -541,6 +541,7 @@
 "importFilters_title" = "استيراد الفلاتر";
 "importFilters_sectionTitle" = "فلاتر للاستيراد";
 "importFilters_subtitle" = "اضغط على قائمة لمراجعة الفلاتر في هذا الملف واختيار ما تريد إضافته. الفلاتر الموجودة مسبقًا على هذا الجهاز تُتخطى. لا يُستبدل شيء ولا يُحذف.";
+"importFilters_willClear" = "ستُحذف كل الفلاتر الموجودة";
 "importFilters_duplicates" = "موجودة مسبقًا";
 "importFilters_invalid" = "تم التخطي";
 "importFilters_confirm" = "استيراد";

--- a/Simply Filter SMS/Resources/de.lproj/Localizable.strings
+++ b/Simply Filter SMS/Resources/de.lproj/Localizable.strings
@@ -541,6 +541,7 @@
 "importFilters_title" = "Filter importieren";
 "importFilters_sectionTitle" = "Zu importierende Filter";
 "importFilters_subtitle" = "Tippe auf eine Liste, um die Filter in dieser Datei zu prüfen und auszuwählen, welche hinzugefügt werden. Filter, die auf diesem Gerät bereits vorhanden sind, werden übersprungen. Nichts wird überschrieben oder gelöscht.";
+"importFilters_willClear" = "Alle vorhandenen Filter werden gelöscht";
 "importFilters_duplicates" = "Bereits vorhanden";
 "importFilters_invalid" = "Übersprungen";
 "importFilters_confirm" = "Importieren";

--- a/Simply Filter SMS/Resources/en.lproj/Localizable.strings
+++ b/Simply Filter SMS/Resources/en.lproj/Localizable.strings
@@ -330,6 +330,7 @@
 "importFilters_title" = "Import Filters";
 "importFilters_sectionTitle" = "Filters to Import";
 "importFilters_subtitle" = "Tap a list to review the filters in this file and choose which ones to add. Filters that already exist on this device are skipped. Nothing is overwritten or deleted.";
+"importFilters_willClear" = "All existing filters will be deleted";
 "importFilters_duplicates" = "Already exist";
 "importFilters_invalid" = "Skipped";
 "importFilters_confirm" = "Import";

--- a/Simply Filter SMS/Resources/es.lproj/Localizable.strings
+++ b/Simply Filter SMS/Resources/es.lproj/Localizable.strings
@@ -541,6 +541,7 @@
 "importFilters_title" = "Importar filtros";
 "importFilters_sectionTitle" = "Filtros a importar";
 "importFilters_subtitle" = "Toca una lista para revisar los filtros de este archivo y elegir cuáles añadir. Los filtros que ya existen en este dispositivo se omiten. No se sobrescribe ni se elimina nada.";
+"importFilters_willClear" = "Se eliminarán todos los filtros existentes";
 "importFilters_duplicates" = "Ya existen";
 "importFilters_invalid" = "Omitidos";
 "importFilters_confirm" = "Importar";

--- a/Simply Filter SMS/Resources/fr.lproj/Localizable.strings
+++ b/Simply Filter SMS/Resources/fr.lproj/Localizable.strings
@@ -541,6 +541,7 @@
 "importFilters_title" = "Importer les filtres";
 "importFilters_sectionTitle" = "Filtres à importer";
 "importFilters_subtitle" = "Touchez une liste pour examiner les filtres de ce fichier et choisir ceux à ajouter. Les filtres déjà présents sur cet appareil sont ignorés. Rien n’est écrasé ni supprimé.";
+"importFilters_willClear" = "Tous les filtres existants seront supprimés";
 "importFilters_duplicates" = "Déjà présents";
 "importFilters_invalid" = "Ignorés";
 "importFilters_confirm" = "Importer";

--- a/Simply Filter SMS/Resources/he.lproj/Localizable.strings
+++ b/Simply Filter SMS/Resources/he.lproj/Localizable.strings
@@ -541,6 +541,7 @@
 "importFilters_title" = "ייבוא פילטרים";
 "importFilters_sectionTitle" = "פילטרים לייבוא";
 "importFilters_subtitle" = "הקישו על רשימה כדי לעיין בפילטרים שבקובץ ולבחור מה להוסיף. פילטרים שכבר קיימים במכשיר הזה מדולגים. שום דבר לא יוחלף ולא יימחק.";
+"importFilters_willClear" = "כל הפילטרים הקיימים יימחקו";
 "importFilters_duplicates" = "כבר קיימים";
 "importFilters_invalid" = "לא תקינים";
 "importFilters_confirm" = "ייבוא";

--- a/Simply Filter SMS/Resources/it.lproj/Localizable.strings
+++ b/Simply Filter SMS/Resources/it.lproj/Localizable.strings
@@ -541,6 +541,7 @@
 "importFilters_title" = "Importa filtri";
 "importFilters_sectionTitle" = "Filtri da importare";
 "importFilters_subtitle" = "Tocca un elenco per rivedere i filtri di questo file e scegliere quali aggiungere. I filtri già presenti su questo dispositivo vengono ignorati. Nulla viene sovrascritto o eliminato.";
+"importFilters_willClear" = "Tutti i filtri esistenti verranno eliminati";
 "importFilters_duplicates" = "Già presenti";
 "importFilters_invalid" = "Ignorati";
 "importFilters_confirm" = "Importa";

--- a/Simply Filter SMS/Resources/ja.lproj/Localizable.strings
+++ b/Simply Filter SMS/Resources/ja.lproj/Localizable.strings
@@ -541,6 +541,7 @@
 "importFilters_title" = "フィルタを読み込む";
 "importFilters_sectionTitle" = "読み込むフィルタ";
 "importFilters_subtitle" = "リストをタップして、このファイルのフィルタを確認し、追加するものを選べます。このデバイスにすでに存在するフィルタはスキップされます。上書きや削除は行われません。";
+"importFilters_willClear" = "既存のフィルタはすべて削除されます";
 "importFilters_duplicates" = "既存";
 "importFilters_invalid" = "スキップ";
 "importFilters_confirm" = "読み込む";

--- a/Simply Filter SMS/Resources/ko.lproj/Localizable.strings
+++ b/Simply Filter SMS/Resources/ko.lproj/Localizable.strings
@@ -541,6 +541,7 @@
 "importFilters_title" = "필터 가져오기";
 "importFilters_sectionTitle" = "가져올 필터";
 "importFilters_subtitle" = "목록을 탭하여 이 파일의 필터를 확인하고 추가할 항목을 고르세요. 이 기기에 이미 있는 필터는 건너뜁니다. 덮어쓰거나 삭제되지 않습니다.";
+"importFilters_willClear" = "기존 필터가 모두 삭제됩니다";
 "importFilters_duplicates" = "이미 있음";
 "importFilters_invalid" = "건너뜀";
 "importFilters_confirm" = "가져오기";

--- a/Simply Filter SMS/Resources/pt-BR.lproj/Localizable.strings
+++ b/Simply Filter SMS/Resources/pt-BR.lproj/Localizable.strings
@@ -541,6 +541,7 @@
 "importFilters_title" = "Importar filtros";
 "importFilters_sectionTitle" = "Filtros para importar";
 "importFilters_subtitle" = "Toque em uma lista para revisar os filtros deste arquivo e escolher quais adicionar. Filtros que já existem neste dispositivo são ignorados. Nada é substituído ou excluído.";
+"importFilters_willClear" = "Todos os filtros existentes serão excluídos";
 "importFilters_duplicates" = "Já existem";
 "importFilters_invalid" = "Ignorados";
 "importFilters_confirm" = "Importar";

--- a/Simply Filter SMS/View Layer/Others/PersistentStoreReload.swift
+++ b/Simply Filter SMS/View Layer/Others/PersistentStoreReload.swift
@@ -1,0 +1,34 @@
+//
+//  PersistentStoreReload.swift
+//  Simply Filter SMS
+//
+//  Created by Adi Ben-Dahan on 24/08/2026.
+//
+
+import SwiftUI
+
+
+protocol PersistentStoreReloadRefreshing: AnyObject {
+    func refresh()
+}
+
+protocol ViewWithPersistentStoreReload: View {
+    associatedtype RefreshModel: PersistentStoreReloadRefreshing
+    var model: RefreshModel { get }
+}
+
+struct PersistentStoreReloadModifier<Model: PersistentStoreReloadRefreshing>: ViewModifier {
+    let model: Model
+
+    func body(content: Content) -> some View {
+        content.onReceive(NotificationCenter.default.publisher(for: .persistentStoreReloaded)) { _ in
+            model.refresh()
+        }
+    }
+}
+
+extension ViewWithPersistentStoreReload {
+    var persistentStoreReload: PersistentStoreReloadModifier<RefreshModel> {
+        PersistentStoreReloadModifier(model: model)
+    }
+}

--- a/Simply Filter SMS/View Layer/Screens/AppHomeView.swift
+++ b/Simply Filter SMS/View Layer/Screens/AppHomeView.swift
@@ -10,7 +10,7 @@ import StoreKit
 import UniformTypeIdentifiers
 
 //MARK: - View -
-struct AppHomeView: View {
+struct AppHomeView: View, ViewWithPersistentStoreReload {
     
     @Environment(\.isPreview)
     var isPreview
@@ -285,6 +285,7 @@ struct AppHomeView: View {
             self.model.requestSheet(.about)
         })
         .modifier(EmbeddedNotificationView(model: self.model.notification))
+        .modifier(persistentStoreReload)
         .sheet(item: $model.sheetScreen) {
             self.model.refresh()
             if !self.model.completeInterruptedSheet(), !isPreview {
@@ -470,7 +471,7 @@ struct AppHomeView: View {
 //MARK: - ViewModel -
 extension AppHomeView {
     
-    class ViewModel: BaseViewModel, ObservableObject {
+    class ViewModel: BaseViewModel, ObservableObject, PersistentStoreReloadRefreshing {
         @Published private(set) var filters: [Filter]
         @Published private(set) var title: String
         @Published private(set) var isAutomaticFilteringOn: Bool

--- a/Simply Filter SMS/View Layer/Screens/FilterListView.swift
+++ b/Simply Filter SMS/View Layer/Screens/FilterListView.swift
@@ -10,7 +10,7 @@ import NaturalLanguage
 
 
 //MARK: - View -
-struct FilterListView: View {
+struct FilterListView: View, ViewWithPersistentStoreReload {
     
     @Environment(\.presentationMode)
     var presentationMode: Binding<PresentationMode>
@@ -141,6 +141,7 @@ struct FilterListView: View {
             }
         }
         } // ScrollViewReader
+        .modifier(persistentStoreReload)
     }
     
     @ViewBuilder
@@ -254,7 +255,7 @@ struct FilterListView: View {
 //MARK: - ViewModel -
 extension FilterListView {
     
-    class ViewModel: BaseViewModel, ObservableObject {
+    class ViewModel: BaseViewModel, ObservableObject, PersistentStoreReloadRefreshing {
         @Published private(set) var filters: [Filter]
         @Published private(set) var rowViewModels: [FilterListRowView.ViewModel] = []
         @Published private(set) var filterType: FilterType

--- a/Simply Filter SMS/View Layer/Screens/FilterListView.swift
+++ b/Simply Filter SMS/View Layer/Screens/FilterListView.swift
@@ -42,10 +42,12 @@ struct FilterListView: View, ViewWithPersistentStoreReload {
                         model: rowModel)
                     .environment(\.editMode, $model.editMode)
                     .id(rowModel.id)
+                    .tag(rowModel.filter)
                 }
                 .onDelete {
                     self.model.deleteFilters(withOffsets: $0, rowViewModels: self.model.regularRowViewModels)
                 }
+                .deleteDisabled(self.model.editMode.isEditing)
             } header: {
                 if self.model.regularFilters.count > 0 {
                     HStack {
@@ -79,10 +81,12 @@ struct FilterListView: View, ViewWithPersistentStoreReload {
                             model: rowModel)
                         .environment(\.editMode, $model.editMode)
                         .id(rowModel.id)
+                        .tag(rowModel.filter)
                     }
                     .onDelete {
                         self.model.deleteFilters(withOffsets: $0, rowViewModels: self.model.regexRowViewModels)
                     }
+                    .deleteDisabled(self.model.editMode.isEditing)
                 } header: {
                     Text("addFilter_match_regex"~)
                 } footer: {

--- a/Simply Filter SMS/View Layer/Screens/FilterTransferPreviewView.swift
+++ b/Simply Filter SMS/View Layer/Screens/FilterTransferPreviewView.swift
@@ -28,7 +28,7 @@ struct FilterTransferPreviewView: View {
                 Section {
                     ForEach(FilterType.allCases
                         .sorted(by: { $0.sortIndex < $1.sortIndex })
-                        .filter({ self.model.candidates(for: $0).isEmpty == false }), id: \.self) { filterType in
+                        .filter({ self.model.candidates(for: $0).isEmpty == false || self.model.willForceClear($0) }), id: \.self) { filterType in
                         NavigationLink {
                             FilterTransferCandidateListView(model: self.model, filterType: filterType)
                         } label: {
@@ -37,8 +37,17 @@ struct FilterTransferPreviewView: View {
                                     .foregroundColor(filterType.iconColor)
                                     .frame(maxWidth: typeIconSize, maxHeight: .infinity, alignment: .center)
 
-                                Text(filterType.name)
-                                    .padding(.leading, 8)
+                                VStack(alignment: .leading, spacing: 0) {
+                                    Text(filterType.name)
+                                        .padding(.leading, 8)
+
+                                    if self.model.willForceClear(filterType) {
+                                        Text("\(Image(systemName: "exclamationmark.triangle.fill")) \("importFilters_willClear"~)")
+                                            .font(.caption2)
+                                            .foregroundColor(.red)
+                                            .padding(.leading, 8)
+                                    }
+                                }
 
                                 Spacer()
 
@@ -49,6 +58,7 @@ struct FilterTransferPreviewView: View {
                             }
                         }
                         .accentColor(Color.primary.opacity(0.35))
+                        .disabled(self.model.candidates(for: filterType).isEmpty)
                     }
                 } header: {
                     Text(self.model.sectionTitle)
@@ -265,6 +275,10 @@ extension FilterTransferPreviewView {
             return self.selectedIDs.count
         }
 
+        func willForceClear(_ type: FilterType) -> Bool {
+            return self.kind == .importFilters && self.preview.forceClearTypes.contains(type)
+        }
+
         func candidates(for type: FilterType) -> [FilterTransferCandidate] {
             return self.preview.candidates.filter({ $0.type == type })
         }
@@ -353,7 +367,8 @@ struct FilterTransferPreviewView_Previews: PreviewProvider {
                                    target: FilterTarget.body.exportKey,
                                    matching: FilterMatching.contains.exportKey,
                                    caseSensitivity: FilterCase.caseInsensitive.exportKey)
-            ]
+            ],
+            forceClearBeforeImport: nil
         )
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601

--- a/Simply Filter SMS/View Layer/Screens/LanguageListView.swift
+++ b/Simply Filter SMS/View Layer/Screens/LanguageListView.swift
@@ -12,7 +12,7 @@ import CryptoKit
 
 
 //MARK: - View -
-struct LanguageListView: View {
+struct LanguageListView: View, ViewWithPersistentStoreReload {
     
     @Environment(\.colorScheme)
     var colorScheme: ColorScheme
@@ -162,6 +162,7 @@ struct LanguageListView: View {
         .onAppear {
             self.model.startMonitoring()
         }
+        .modifier(persistentStoreReload)
     }
 }
 
@@ -173,7 +174,7 @@ extension LanguageListView {
         case blockLanguage, automaticBlocking
     }
     
-    class ViewModel: BaseViewModel, @unchecked Sendable, ObservableObject, Identifiable {
+    class ViewModel: BaseViewModel, @unchecked Sendable, ObservableObject, Identifiable, PersistentStoreReloadRefreshing {
         let id = UUID()
         @Published private(set) var mode: LanguageListView.Mode
         @Published private(set) var title: String

--- a/Tests/FilterTransferManagerTests.swift
+++ b/Tests/FilterTransferManagerTests.swift
@@ -111,6 +111,35 @@ class FilterTransferManagerTests: XCTestCase {
         XCTAssertEqual(texts, ["keep-me", "promo", "new-one"])
     }
 
+    func test_forceClearBeforeImport_clearsListedTypesThenAdds() throws {
+        self.persistanceManager.addFilter(text: "old-deny",
+                                          type: .deny,
+                                          denyFolder: .junk,
+                                          filterTarget: .all,
+                                          filterMatching: .contains,
+                                          filterCase: .caseInsensitive)
+        self.persistanceManager.addFilter(text: "keep-allow",
+                                          type: .allow,
+                                          denyFolder: .junk,
+                                          filterTarget: .all,
+                                          filterMatching: .contains,
+                                          filterCase: .caseInsensitive)
+
+        let data = try self.payload(filters: [
+            record(text: "old-deny", type: "deny"),
+            record(text: "fresh-deny", type: "deny")
+        ], forceClearBeforeImport: ["deny"])
+
+        let preview = try self.testSubject.queueImport(data: data)
+        let result = self.testSubject.importFilters(preview.candidates)
+
+        XCTAssertEqual(result.added, 2)
+        XCTAssertEqual(result.duplicateCount, 0)
+        let denyTexts = Set(self.persistanceManager.fetchFilterRecords(for: .deny).compactMap({ $0.text }))
+        XCTAssertEqual(denyTexts, ["old-deny", "fresh-deny"])
+        XCTAssertEqual(self.persistanceManager.fetchFilterRecords(for: .allow).first?.text, "keep-allow")
+    }
+
     func test_preview_skipsIntraFileDuplicates() throws {
         let data = try self.payload(filters: [
             record(text: "same", type: "deny"),
@@ -289,14 +318,18 @@ class FilterTransferManagerTests: XCTestCase {
 
     private func payload(format: String = FilterExportPayload.formatIdentifier,
                          version: Int = FilterExportPayload.currentVersion,
-                         filters: [[String: String]]) throws -> Data {
-        let object: [String: Any] = [
+                         filters: [[String: String]],
+                         forceClearBeforeImport: [String]? = nil) throws -> Data {
+        var object: [String: Any] = [
             "format": format,
             "version": version,
             "exportedAt": "2026-08-15T18:00:00Z",
             "appVersion": "1.0",
             "filters": filters
         ]
+        if let forceClearBeforeImport {
+            object["forceClearBeforeImport"] = forceClearBeforeImport
+        }
         return try JSONSerialization.data(withJSONObject: object)
     }
 }

--- a/docs/FRAMEWORK.md
+++ b/docs/FRAMEWORK.md
@@ -319,6 +319,7 @@ extension NSNotification.Name {
     static let automaticFiltersUpdated
     static let onClipboardSet
     static let filtersStateChanged
+    static let persistentStoreReloaded
 }
 ```
 
@@ -337,6 +338,8 @@ On **successful import**: posts `.cloudSyncOperationComplete` (toast + refresh) 
 ### Recovery Logic
 
 When network comes online after a failed sync, or setup fails while online, reloads the CloudKit container. Failed setup schedules up to two delayed retries (5s, then 10s); a pending retry is cancelled if network recovery reloads first or setup succeeds. Retries run unless the network is known offline (`.unknown` is allowed — path monitor may not have reported yet).
+
+`PersistanceManager.reloadContainer()` resets the view context (invalidating all managed objects), loads a new container, then posts `.persistentStoreReloaded` on the main queue. Screens that cache Core Data objects conform to `ViewWithPersistentStoreReload` and apply `.modifier(persistentStoreReload)` (`PersistentStoreReload.swift`).
 ---
 
 ## TipJarManager


### PR DESCRIPTION
## Summary
- Refresh filter screens after a Core Data store reload so list rows never keep dead objects (fixes Simulator crash after inline edit when iCloud isn’t signed in).
- Restore filter-list multi-select checkboxes in edit mode (broken when rows switched to UUID-backed ViewModels).
- Support undocumented `forceClearBeforeImport` on import files to wipe listed filter types before merging, with a red delete warning on the import preview.
- Bump marketing version to 3.1.1.

## Test plan
- [x] Simulator, no iCloud: Allowed/Blocked list → inline edit → tap outside to exit — no crash; list still usable
- [x] Filter list → Edit → multi-select shows checkboxes (not red delete); swipe-delete still works outside edit mode
- [x] Import a normal `.sfsfilters` file — merge-only behavior unchanged; no wipe warning
- [x] Import a file with `"forceClearBeforeImport": ["allow"]` (and/or deny / denyLanguage) — red subtitle on those rows; confirm deletes existing filters of those types then adds selected
- [x] Confirm version shows 3.1.1


Made with [Cursor](https://cursor.com)