### PR TITLE
Fix Large Text layouts across screens

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,8 +21,8 @@ Open `Simply Filter SMS.xcodeproj` in Xcode. No package managers (SPM/CocoaPods)
 
 **Command-line build/test:**
 ```bash
-xcodebuild -project "Simply Filter SMS.xcodeproj" -scheme "Simply Filter SMS" -destination 'platform=iOS Simulator,name=iPhone 16' build
-xcodebuild -project "Simply Filter SMS.xcodeproj" -scheme "Simply Filter SMS" -destination 'platform=iOS Simulator,name=iPhone 16' test
+xcodebuild -project "Simply Filter SMS.xcodeproj" -scheme "Simply Filter SMS" -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build
+xcodebuild -project "Simply Filter SMS.xcodeproj" -scheme "Simply Filter SMS" -destination 'platform=iOS Simulator,name=iPhone 17 Pro' test
 ```
 
 **Localization:** BartyCrouch normalizes `.strings` files (English + Hebrew). Config in `.bartycrouch.toml`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Open `Simply Filter SMS.xcodeproj` in Xcode. No package managers (SPM/CocoaPods)
 **Command-line build/test:**
 ```bash
 xcodebuild -project "Simply Filter SMS.xcodeproj" -scheme "Simply Filter SMS" -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build
-xcodebuild -project "Simply Filter SMS.xcodeproj" -scheme "Simply Filter SMS" -destination 'platform=iOS Simulator,name=iPhone 17 Pro' test
+xcodebuild -project "Simply Filter SMS.xcodeproj" -scheme "Tests" -destination 'platform=iOS Simulator,name=iPhone 17 Pro' test
 ```
 
 **Localization:** BartyCrouch normalizes `.strings` files (English + Hebrew). Config in `.bartycrouch.toml`.

--- a/Simply Filter SMS.xcodeproj/project.pbxproj
+++ b/Simply Filter SMS.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		698322832F50AD35008FFD1D /* XCUIElementExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 698322822F50AD2C008FFD1D /* XCUIElementExtensions.swift */; };
 		6987D7FF27AACA9100B3DB84 /* mock_MessageEvaluationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6987D7FE27AACA9100B3DB84 /* mock_MessageEvaluationManager.swift */; };
 		6987D80227AAD9E400B3DB84 /* ViewModfiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6987D80127AAD9E400B3DB84 /* ViewModfiers.swift */; };
+		DTLAY0UT00000001B0000001 /* DynamicTypeLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = DTLAY0UT00000001F0000001 /* DynamicTypeLayout.swift */; };
 		698FBAFE27B44A0700435699 /* NetworkSyncManagerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 698FBAFD27B44A0700435699 /* NetworkSyncManagerProtocol.swift */; };
 		698FBB0027B4629800435699 /* mock_NetworkSyncManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 698FBAFF27B4629800435699 /* mock_NetworkSyncManager.swift */; };
 		699F55802778BB3100AD7C64 /* AddFilterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 699F557F2778BB3100AD7C64 /* AddFilterView.swift */; };
@@ -272,6 +273,7 @@
 		698322822F50AD2C008FFD1D /* XCUIElementExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCUIElementExtensions.swift; sourceTree = "<group>"; };
 		6987D7FE27AACA9100B3DB84 /* mock_MessageEvaluationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = mock_MessageEvaluationManager.swift; sourceTree = "<group>"; };
 		6987D80127AAD9E400B3DB84 /* ViewModfiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModfiers.swift; sourceTree = "<group>"; };
+		DTLAY0UT00000001F0000001 /* DynamicTypeLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicTypeLayout.swift; sourceTree = "<group>"; };
 		698FBAFD27B44A0700435699 /* NetworkSyncManagerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkSyncManagerProtocol.swift; sourceTree = "<group>"; };
 		698FBAFF27B4629800435699 /* mock_NetworkSyncManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = mock_NetworkSyncManager.swift; sourceTree = "<group>"; };
 		699F557F2778BB3100AD7C64 /* AddFilterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddFilterView.swift; sourceTree = "<group>"; };
@@ -669,6 +671,7 @@
 				690F09C427AC22CD00BA481F /* BaseViewModel.swift */,
 				690F054D278200B60036553B /* ButtonStyles.swift */,
 				6987D80127AAD9E400B3DB84 /* ViewModfiers.swift */,
+				DTLAY0UT00000001F0000001 /* DynamicTypeLayout.swift */,
 				A24PSR0FILE0001F0000001 /* PersistentStoreReload.swift */,
 				BF981F0B1B564B22AF8F9F0D /* ConfettiView.swift */,
 				6941FE1B277FDBE700B99539 /* MailView.swift */,
@@ -1017,6 +1020,7 @@
 				69B2A9AB279CD964000DFAFC /* PersistanceManager.swift in Sources */,
 				69F4096F27B948D800749552 /* AutomaticFilterListsResponse.swift in Sources */,
 				6987D80227AAD9E400B3DB84 /* ViewModfiers.swift in Sources */,
+				DTLAY0UT00000001B0000001 /* DynamicTypeLayout.swift in Sources */,
 				A24PSR0FILE0001B0000001 /* PersistentStoreReload.swift in Sources */,
 				698FBAFE27B44A0700435699 /* NetworkSyncManagerProtocol.swift in Sources */,
 				69CD70D62770D4D100F91A2F /* Simply-Filter-SMS.xcdatamodeld in Sources */,

--- a/Simply Filter SMS.xcodeproj/project.pbxproj
+++ b/Simply Filter SMS.xcodeproj/project.pbxproj
@@ -1146,7 +1146,7 @@
 				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
 				CODE_SIGN_ENTITLEMENTS = "Reporting Extension/Reporting Extension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 202608261104;
+				CURRENT_PROJECT_VERSION = 202608270042;
 				DEVELOPMENT_TEAM = AL28LDR9PU;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Reporting Extension/Info.plist";
@@ -1367,7 +1367,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Simply Filter SMS/Resources/Simply Filter SMS.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 202608261104;
+				CURRENT_PROJECT_VERSION = 202608270042;
 				DEVELOPMENT_ASSET_PATHS = "\"Simply Filter SMS/Resources/Preview Content\"";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = AL28LDR9PU;
 				ENABLE_PREVIEWS = YES;
@@ -1406,7 +1406,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Simply Filter SMS/Resources/Simply Filter SMS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 202608261104;
+				CURRENT_PROJECT_VERSION = 202608270042;
 				DEVELOPMENT_ASSET_PATHS = "\"Simply Filter SMS/Resources/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1440,7 +1440,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Message Filter Extension/Simply Filter SMS Extension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 202608261104;
+				CURRENT_PROJECT_VERSION = 202608270042;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Message Filter Extension/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Simply Filter SMS Extension";
@@ -1466,7 +1466,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Message Filter Extension/Simply Filter SMS Extension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 202608261104;
+				CURRENT_PROJECT_VERSION = 202608270042;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Message Filter Extension/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Simply Filter SMS Extension";
@@ -1493,7 +1493,7 @@
 				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
 				CODE_SIGN_ENTITLEMENTS = "Reporting Extension/Reporting Extension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 202608261104;
+				CURRENT_PROJECT_VERSION = 202608270042;
 				DEVELOPMENT_TEAM = AL28LDR9PU;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Reporting Extension/Info.plist";

--- a/Simply Filter SMS.xcodeproj/project.pbxproj
+++ b/Simply Filter SMS.xcodeproj/project.pbxproj
@@ -67,7 +67,6 @@
 		698322832F50AD35008FFD1D /* XCUIElementExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 698322822F50AD2C008FFD1D /* XCUIElementExtensions.swift */; };
 		6987D7FF27AACA9100B3DB84 /* mock_MessageEvaluationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6987D7FE27AACA9100B3DB84 /* mock_MessageEvaluationManager.swift */; };
 		6987D80227AAD9E400B3DB84 /* ViewModfiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6987D80127AAD9E400B3DB84 /* ViewModfiers.swift */; };
-		DTLAY0UT00000001B0000001 /* DynamicTypeLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = DTLAY0UT00000001F0000001 /* DynamicTypeLayout.swift */; };
 		698FBAFE27B44A0700435699 /* NetworkSyncManagerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 698FBAFD27B44A0700435699 /* NetworkSyncManagerProtocol.swift */; };
 		698FBB0027B4629800435699 /* mock_NetworkSyncManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 698FBAFF27B4629800435699 /* mock_NetworkSyncManager.swift */; };
 		699F55802778BB3100AD7C64 /* AddFilterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 699F557F2778BB3100AD7C64 /* AddFilterView.swift */; };
@@ -143,6 +142,7 @@
 		C669D4A928A74191AC2501126961491F /* PressDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E6D0065DEA04AF1B2239E6CB0454D40 /* PressDetector.swift */; };
 		D84016F55AA644ED830854A2B12057F5 /* RefreshControlDisabler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E6E3998CCF6470F8F6A40A36EE19752 /* RefreshControlDisabler.swift */; };
 		D852110664A64E9DAD508BFA /* Reporting Extension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 1355C48B10FE4519937D804C /* Reporting Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		DTLAY0UT00000001B0000001 /* DynamicTypeLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = DTLAY0UT00000001F0000001 /* DynamicTypeLayout.swift */; };
 		E35862B339E54B54A79D65A2AF0C8C10 /* DebugDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 461600A3BF8E48F5A39D9B0C9CC8C77D /* DebugDataManager.swift */; };
 		E4BD986313F1C68187D4B32B /* EnableReportingExtensionStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00FDD7FD5B3D7601BF34B0C6 /* EnableReportingExtensionStep.swift */; };
 		EABCA17395164EA18CE84A83BA8BAF39 /* DebugDataManagerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76CE78982A134F52B1487E949E3617F9 /* DebugDataManagerProtocol.swift */; };
@@ -273,7 +273,6 @@
 		698322822F50AD2C008FFD1D /* XCUIElementExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCUIElementExtensions.swift; sourceTree = "<group>"; };
 		6987D7FE27AACA9100B3DB84 /* mock_MessageEvaluationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = mock_MessageEvaluationManager.swift; sourceTree = "<group>"; };
 		6987D80127AAD9E400B3DB84 /* ViewModfiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModfiers.swift; sourceTree = "<group>"; };
-		DTLAY0UT00000001F0000001 /* DynamicTypeLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicTypeLayout.swift; sourceTree = "<group>"; };
 		698FBAFD27B44A0700435699 /* NetworkSyncManagerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkSyncManagerProtocol.swift; sourceTree = "<group>"; };
 		698FBAFF27B4629800435699 /* mock_NetworkSyncManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = mock_NetworkSyncManager.swift; sourceTree = "<group>"; };
 		699F557F2778BB3100AD7C64 /* AddFilterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddFilterView.swift; sourceTree = "<group>"; };
@@ -351,6 +350,7 @@
 		DD0B53FCE983DFBEFBCE70F7 /* ReportingExtensionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportingExtensionViewController.swift; sourceTree = "<group>"; };
 		DDFBDEA463B84374A61E16E73070A6E4 /* mock_DebugDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = mock_DebugDataManager.swift; sourceTree = "<group>"; };
 		DEE20EFA594C4A0FBF07D691 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = ko; path = ko.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		DTLAY0UT00000001F0000001 /* DynamicTypeLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicTypeLayout.swift; sourceTree = "<group>"; };
 		F0956A6375EFA3BB6C2877B5 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
 		F0956A6375EFA3BB6C2877B6 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = ja; path = ja.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -1146,13 +1146,13 @@
 				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
 				CODE_SIGN_ENTITLEMENTS = "Reporting Extension/Reporting Extension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 202608242020;
+				CURRENT_PROJECT_VERSION = 202608261104;
 				DEVELOPMENT_TEAM = AL28LDR9PU;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Reporting Extension/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Simply Filter SMS Reporting Extension";
 				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
-				MARKETING_VERSION = 3.1.1;
+				MARKETING_VERSION = 3.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.grizz.apps.dev.Simply-Filter-SMS.Simply-Filter-SMS-Report-Extension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1367,7 +1367,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Simply Filter SMS/Resources/Simply Filter SMS.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 202608242020;
+				CURRENT_PROJECT_VERSION = 202608261104;
 				DEVELOPMENT_ASSET_PATHS = "\"Simply Filter SMS/Resources/Preview Content\"";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = AL28LDR9PU;
 				ENABLE_PREVIEWS = YES;
@@ -1385,7 +1385,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.1.1;
+				MARKETING_VERSION = 3.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.grizz.apps.dev.Simply-Filter-SMS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "May 22: Simply Filter SMS - Dev";
@@ -1406,7 +1406,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Simply Filter SMS/Resources/Simply Filter SMS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 202608242020;
+				CURRENT_PROJECT_VERSION = 202608261104;
 				DEVELOPMENT_ASSET_PATHS = "\"Simply Filter SMS/Resources/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1423,7 +1423,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.1.1;
+				MARKETING_VERSION = 3.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.grizz.apps.dev.Simply-Filter-SMS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1440,7 +1440,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Message Filter Extension/Simply Filter SMS Extension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 202608242020;
+				CURRENT_PROJECT_VERSION = 202608261104;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Message Filter Extension/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Simply Filter SMS Extension";
@@ -1451,7 +1451,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.1.1;
+				MARKETING_VERSION = 3.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.grizz.apps.dev.Simply-Filter-SMS.Simply-Filter-SMS-Extension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1466,7 +1466,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Message Filter Extension/Simply Filter SMS Extension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 202608242020;
+				CURRENT_PROJECT_VERSION = 202608261104;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Message Filter Extension/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Simply Filter SMS Extension";
@@ -1477,7 +1477,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 3.1.1;
+				MARKETING_VERSION = 3.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.grizz.apps.dev.Simply-Filter-SMS.Simply-Filter-SMS-Extension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1493,13 +1493,13 @@
 				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
 				CODE_SIGN_ENTITLEMENTS = "Reporting Extension/Reporting Extension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 202608242020;
+				CURRENT_PROJECT_VERSION = 202608261104;
 				DEVELOPMENT_TEAM = AL28LDR9PU;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Reporting Extension/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Simply Filter SMS Reporting Extension";
 				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
-				MARKETING_VERSION = 3.1.1;
+				MARKETING_VERSION = 3.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.grizz.apps.dev.Simply-Filter-SMS.Simply-Filter-SMS-Report-Extension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/Simply Filter SMS.xcodeproj/project.pbxproj
+++ b/Simply Filter SMS.xcodeproj/project.pbxproj
@@ -1146,7 +1146,7 @@
 				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
 				CODE_SIGN_ENTITLEMENTS = "Reporting Extension/Reporting Extension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 202608270042;
+				CURRENT_PROJECT_VERSION = 202608272300;
 				DEVELOPMENT_TEAM = AL28LDR9PU;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Reporting Extension/Info.plist";
@@ -1367,7 +1367,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Simply Filter SMS/Resources/Simply Filter SMS.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 202608270042;
+				CURRENT_PROJECT_VERSION = 202608272300;
 				DEVELOPMENT_ASSET_PATHS = "\"Simply Filter SMS/Resources/Preview Content\"";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = AL28LDR9PU;
 				ENABLE_PREVIEWS = YES;
@@ -1406,7 +1406,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Simply Filter SMS/Resources/Simply Filter SMS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 202608270042;
+				CURRENT_PROJECT_VERSION = 202608272300;
 				DEVELOPMENT_ASSET_PATHS = "\"Simply Filter SMS/Resources/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1440,7 +1440,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Message Filter Extension/Simply Filter SMS Extension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 202608270042;
+				CURRENT_PROJECT_VERSION = 202608272300;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Message Filter Extension/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Simply Filter SMS Extension";
@@ -1466,7 +1466,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Message Filter Extension/Simply Filter SMS Extension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 202608270042;
+				CURRENT_PROJECT_VERSION = 202608272300;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Message Filter Extension/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Simply Filter SMS Extension";
@@ -1493,7 +1493,7 @@
 				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
 				CODE_SIGN_ENTITLEMENTS = "Reporting Extension/Reporting Extension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 202608270042;
+				CURRENT_PROJECT_VERSION = 202608272300;
 				DEVELOPMENT_TEAM = AL28LDR9PU;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Reporting Extension/Info.plist";

--- a/Simply Filter SMS/Simply_Filter_SMSApp.swift
+++ b/Simply Filter SMS/Simply_Filter_SMSApp.swift
@@ -19,6 +19,7 @@ struct Simply_Filter_SMSApp: App {
     var body: some Scene {
         WindowGroup {
             AppHomeView(model: homeModel)
+                .adaptiveLayoutEnvironment()
         }
     }
 }

--- a/Simply Filter SMS/View Layer/Others/CustomPlaceholderView.swift
+++ b/Simply Filter SMS/View Layer/Others/CustomPlaceholderView.swift
@@ -39,21 +39,22 @@ struct CustomPlaceholderView: View {
                     .multilineTextAlignment(.center)
                     .padding(.horizontal)
                 
-                HStack {
+                AdaptiveStack(spacing: 5) {
                     Text("placeholder_choose_sub_detail1"~)
                         .font(.body)
                         .foregroundColor(.primary)
                         .multilineTextAlignment(.center)
-                    
+
                     Image(systemName: symbol)
                         .font(.body)
                         .foregroundStyle(.tint)
-                    
+
                     Text("placeholder_choose_sub_detail2"~)
                         .font(.body)
                         .foregroundColor(.primary)
                         .multilineTextAlignment(.center)
                 }
+                .frame(maxWidth: .infinity)
 
             }
             

--- a/Simply Filter SMS/View Layer/Others/DynamicTypeLayout.swift
+++ b/Simply Filter SMS/View Layer/Others/DynamicTypeLayout.swift
@@ -155,13 +155,14 @@ struct FilterRowOptionChip: View {
     let isActive: Bool
 
     private let iconSize: CGFloat = 15
-    private let buttonSize: CGFloat = 29
 
     var body: some View {
         Image(systemName: systemName)
-            .font(.system(size: iconSize))
+            .resizable()
+            .aspectRatio(contentMode: .fit)
             .foregroundStyle(isActive ? AnyShapeStyle(.tint) : AnyShapeStyle(.secondary))
-            .frame(width: buttonSize, height: buttonSize)
+            .frame(width: iconSize, height: iconSize)
+            .padding(7)
             .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
             .overlay(
                 RoundedRectangle(cornerRadius: 8, style: .continuous)

--- a/Simply Filter SMS/View Layer/Others/DynamicTypeLayout.swift
+++ b/Simply Filter SMS/View Layer/Others/DynamicTypeLayout.swift
@@ -1,0 +1,240 @@
+//
+//  DynamicTypeLayout.swift
+//  Simply Filter SMS
+//
+//  Shared adaptive layout for Large Text / accessibility Dynamic Type sizes.
+//
+
+import SwiftUI
+
+enum DynamicTypeLayout {
+    static let stackedThreshold: DynamicTypeSize = .xxLarge
+    static let iconColumnWidth: CGFloat = 28
+    static let stackedSpacing: CGFloat = 8
+    static let stackedVerticalPadding: CGFloat = 4
+
+    static func needsStackedLayout(_ size: DynamicTypeSize) -> Bool {
+        size.isAccessibilitySize || size >= stackedThreshold
+    }
+}
+
+private struct NeedsStackedLayoutKey: EnvironmentKey {
+    static let defaultValue = false
+}
+
+extension EnvironmentValues {
+    var needsStackedLayout: Bool {
+        get { self[NeedsStackedLayoutKey.self] }
+        set { self[NeedsStackedLayoutKey.self] = newValue }
+    }
+}
+
+struct AdaptiveLayoutEnvironment: ViewModifier {
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+    func body(content: Content) -> some View {
+        content.environment(\.needsStackedLayout, DynamicTypeLayout.needsStackedLayout(dynamicTypeSize))
+    }
+}
+
+private struct AdaptiveStackedRowPadding: ViewModifier {
+    @Environment(\.needsStackedLayout) private var needsStackedLayout
+
+    func body(content: Content) -> some View {
+        if needsStackedLayout {
+            content.padding(.vertical, DynamicTypeLayout.stackedVerticalPadding)
+        } else {
+            content
+        }
+    }
+}
+
+/// List row that stacks trailing content below the leading + primary column at large Dynamic Type sizes.
+struct AdaptiveRow<Leading: View, Content: View, Trailing: View>: View {
+    @Environment(\.needsStackedLayout) private var needsStackedLayout
+
+    var stackedTrailingAlignment: HorizontalAlignment = .leading
+    var compactAlignment: VerticalAlignment = .center
+    var compactSpacing: CGFloat = DynamicTypeLayout.stackedSpacing
+    @ViewBuilder var leading: () -> Leading
+    @ViewBuilder var content: () -> Content
+    @ViewBuilder var trailing: () -> Trailing
+
+    var body: some View {
+        if needsStackedLayout {
+            VStack(alignment: .leading, spacing: DynamicTypeLayout.stackedSpacing) {
+                HStack(alignment: .top, spacing: DynamicTypeLayout.stackedSpacing) {
+                    leading()
+                    content()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                trailing()
+                    .frame(maxWidth: .infinity, alignment: Alignment(horizontal: stackedTrailingAlignment, vertical: .center))
+            }
+            .modifier(AdaptiveStackedRowPadding())
+        } else {
+            HStack(alignment: compactAlignment, spacing: compactSpacing) {
+                leading()
+                content()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                trailing()
+            }
+        }
+    }
+}
+
+extension AdaptiveRow where Trailing == EmptyView {
+    init(
+        stackedTrailingAlignment: HorizontalAlignment = .leading,
+        compactAlignment: VerticalAlignment = .center,
+        compactSpacing: CGFloat = DynamicTypeLayout.stackedSpacing,
+        @ViewBuilder leading: @escaping () -> Leading,
+        @ViewBuilder content: @escaping () -> Content
+    ) {
+        self.stackedTrailingAlignment = stackedTrailingAlignment
+        self.compactAlignment = compactAlignment
+        self.compactSpacing = compactSpacing
+        self.leading = leading
+        self.content = content
+        self.trailing = { EmptyView() }
+    }
+}
+
+/// Toggle that moves the switch onto its own row at large Dynamic Type sizes.
+struct AdaptiveToggle<Label: View>: View {
+    @Binding var isOn: Bool
+    @Environment(\.needsStackedLayout) private var needsStackedLayout
+    @ViewBuilder var label: () -> Label
+
+    var body: some View {
+        if needsStackedLayout {
+            VStack(alignment: .leading, spacing: DynamicTypeLayout.stackedSpacing) {
+                label()
+                Toggle(isOn: $isOn) { EmptyView() }
+                    .labelsHidden()
+            }
+            .modifier(AdaptiveStackedRowPadding())
+        } else {
+            Toggle(isOn: $isOn, label: label)
+        }
+    }
+}
+
+/// Inline controls (caption + button) that stack vertically at large Dynamic Type sizes.
+struct AdaptiveFlowRow<Content: View>: View {
+    @Environment(\.needsStackedLayout) private var needsStackedLayout
+    @ViewBuilder var content: () -> Content
+
+    var body: some View {
+        if needsStackedLayout {
+            VStack(alignment: .leading, spacing: 4, content: content)
+        } else {
+            HStack(alignment: .center, spacing: 4, content: content)
+        }
+    }
+}
+
+/// Horizontal group that becomes vertical at large Dynamic Type sizes (e.g. tip cards).
+struct AdaptiveStack<Content: View>: View {
+    @Environment(\.needsStackedLayout) private var needsStackedLayout
+    var spacing: CGFloat = DynamicTypeLayout.stackedSpacing
+    @ViewBuilder var content: () -> Content
+
+    var body: some View {
+        if needsStackedLayout {
+            VStack(spacing: spacing, content: content)
+        } else {
+            HStack(spacing: spacing, content: content)
+        }
+    }
+}
+
+/// Fixed-size filter option chip — does not scale with Dynamic Type (a11y labels live on the Menu).
+struct FilterRowOptionChip: View {
+    let systemName: String
+    let isActive: Bool
+
+    private let iconSize: CGFloat = 15
+    private let buttonSize: CGFloat = 29
+
+    var body: some View {
+        Image(systemName: systemName)
+            .font(.system(size: iconSize))
+            .foregroundStyle(isActive ? AnyShapeStyle(.tint) : AnyShapeStyle(.secondary))
+            .frame(width: buttonSize, height: buttonSize)
+            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .strokeBorder(Color.primary.opacity(0.12), lineWidth: 0.5)
+            )
+    }
+}
+
+/// Section column header with an optional leading accessory (e.g. select-all).
+struct AdaptiveColumnHeader<Leading: View>: View {
+    @Environment(\.needsStackedLayout) private var needsStackedLayout
+
+    @ViewBuilder var leadingAccessory: () -> Leading
+    let primary: String
+    let secondary: String
+    var secondaryIsMuted: Bool = true
+
+    var body: some View {
+        if needsStackedLayout {
+            HStack(alignment: .top, spacing: DynamicTypeLayout.stackedSpacing) {
+                leadingAccessory()
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(primary)
+                    if !secondary.isEmpty {
+                        Text(secondary)
+                            .if(secondaryIsMuted) { $0.foregroundColor(.secondary) }
+                    }
+                }
+            }
+        } else {
+            HStack {
+                leadingAccessory()
+                Text(primary)
+                if !secondary.isEmpty {
+                    Spacer()
+                    Text(secondary)
+                        .if(secondaryIsMuted) { $0.foregroundColor(.secondary) }
+                        .padding(.trailing, 8)
+                }
+            }
+        }
+    }
+}
+
+extension AdaptiveColumnHeader where Leading == EmptyView {
+    init(primary: String, secondary: String, secondaryIsMuted: Bool = true) {
+        self.leadingAccessory = { EmptyView() }
+        self.primary = primary
+        self.secondary = secondary
+        self.secondaryIsMuted = secondaryIsMuted
+    }
+
+    init(leading: String, trailing: String, trailingSecondary: Bool = true) {
+        self.init(primary: leading, secondary: trailing, secondaryIsMuted: trailingSecondary)
+    }
+}
+
+extension View {
+    func adaptiveLayoutEnvironment() -> some View {
+        modifier(AdaptiveLayoutEnvironment())
+    }
+
+    func adaptiveIconColumn(width: CGFloat = DynamicTypeLayout.iconColumnWidth) -> some View {
+        frame(width: width, alignment: .center)
+    }
+
+    func adaptiveStackedRowPadding() -> some View {
+        modifier(AdaptiveStackedRowPadding())
+    }
+
+    /// Caps Dynamic Type for decorative chrome (footer, toasts, badges) that must stay compact.
+    /// VoiceOver labels remain fully accessible; only visual sizing is limited.
+    func limitedDynamicTypeSize(_ max: DynamicTypeSize = .xxxLarge) -> some View {
+        dynamicTypeSize(...max)
+    }
+}

--- a/Simply Filter SMS/View Layer/Others/EnableExtensionStepView.swift
+++ b/Simply Filter SMS/View Layer/Others/EnableExtensionStepView.swift
@@ -14,6 +14,7 @@ struct EnableExtensionStepView: View {
     let isActive: Bool
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.needsStackedLayout) private var needsStackedLayout
     @State private var toggleOn = false
 
     var body: some View {
@@ -42,7 +43,9 @@ struct EnableExtensionStepView: View {
             }
 
             // Right: title + description, toggle at trailing
-            HStack(alignment: .top, spacing: 12) {
+            AdaptiveRow(stackedTrailingAlignment: .trailing, compactAlignment: .top) {
+                EmptyView()
+            } content: {
                 VStack(alignment: .leading, spacing: 4) {
                     HStack(spacing: 6) {
                         if step.showsAppIcon {
@@ -56,19 +59,24 @@ struct EnableExtensionStepView: View {
                         }
                         Text(step.title)
                             .font(.headline)
+                            .fixedSize(horizontal: false, vertical: true)
                     }
                     Text(step.description)
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
-                        .lineLimit(2)
-                        .minimumScaleFactor(0.7)
-                        .frame(height: 40, alignment: .topLeading)
+                        .if(needsStackedLayout) { content in
+                            content.fixedSize(horizontal: false, vertical: true)
+                        }
+                        .if(!needsStackedLayout) { content in
+                            content
+                                .lineLimit(2)
+                                .minimumScaleFactor(0.7)
+                                .frame(height: 40, alignment: .topLeading)
+                        }
                 }
                 .opacity(isActive ? 1.0 : 0.35)
                 .animation(.easeInOut(duration: 0.3), value: isActive)
-
-                Spacer()
-
+            } trailing: {
                 if step.isToggle {
                     Toggle("", isOn: $toggleOn)
                         .labelsHidden()

--- a/Simply Filter SMS/View Layer/Others/FilterListRowView.swift
+++ b/Simply Filter SMS/View Layer/Others/FilterListRowView.swift
@@ -35,7 +35,7 @@ struct FilterListRowView: View {
 
     @ViewBuilder
     private var filterTextColumn: some View {
-        HStack(alignment: .center, spacing: 0) {
+        HStack(alignment: .center) {
             Circle()
                 .fill(.tint)
                 .frame(width: 8, height: 8)
@@ -65,7 +65,6 @@ struct FilterListRowView: View {
                 if blockedLanguage != .undetermined,
                    let localizedName = blockedLanguage.localizedName {
                     Text(localizedName)
-                        .padding(.leading, 8)
                 }
             }
             else {
@@ -108,7 +107,7 @@ struct FilterListRowView: View {
 
     @ViewBuilder
     private var optionButtons: some View {
-        HStack(spacing: 4) {
+        HStack {
             if self.model.filter.filterType.supportsAdvancedOptions {
                 targetMenu
                 if self.model.filter.filterMatching != .regex {

--- a/Simply Filter SMS/View Layer/Others/FilterListRowView.swift
+++ b/Simply Filter SMS/View Layer/Others/FilterListRowView.swift
@@ -20,11 +20,22 @@ struct FilterListRowView: View {
     @State private var showInvalidRegexError = false
     @State private var dotOpacity: Double = 0
 
-    @ScaledMetric(relativeTo: .body) private var optionIconSize: CGFloat = 15
-
     var body: some View {
-        HStack (alignment: .center) {
+        AdaptiveRow {
+            EmptyView()
+        } content: {
+            filterTextColumn
+        } trailing: {
+            if !self.isEditingText {
+                optionButtons
+            }
+        }
+        .accessibilityElement(children: .contain)
+    }
 
+    @ViewBuilder
+    private var filterTextColumn: some View {
+        HStack(alignment: .center, spacing: 0) {
             Circle()
                 .fill(.tint)
                 .frame(width: 8, height: 8)
@@ -54,6 +65,7 @@ struct FilterListRowView: View {
                 if blockedLanguage != .undetermined,
                    let localizedName = blockedLanguage.localizedName {
                     Text(localizedName)
+                        .padding(.leading, 8)
                 }
             }
             else {
@@ -82,6 +94,8 @@ struct FilterListRowView: View {
                         self.showInvalidRegexError = self.model.isLiveInvalidRegex(text: text)
                     })
                     .font(self.model.filter.filterMatching == .regex ? .system(.body, design: .monospaced) : .body)
+                    .frame(minWidth: 0, maxWidth: .infinity, alignment: .leading)
+                    .layoutPriority(1)
 
                 if self.isEditingText && self.showDuplicateError {
                     FilterBadge(text: "addFilter_duplicate"~, color: .red, systemImage: "xmark.circle.fill")
@@ -89,104 +103,108 @@ struct FilterListRowView: View {
                     FilterBadge(text: "addFilter_invalidRegex"~, color: .red, systemImage: "xmark.circle.fill")
                 }
             }
-            
-            Spacer()
-            
-            if !self.isEditingText && self.model.filter.filterType.supportsAdvancedOptions {
-                Menu {
-                    Picker(selection: Binding(
-                        get: { self.model.filter.filterTarget },
-                        set: { self.model.updateFilter(filterTarget: $0) }
-                    )) {
-                        ForEach(FilterTarget.allCases) { filterTarget in
-                            Label(filterTarget.name, systemImage: filterTarget.icon)
-                                .tag(filterTarget)
-                        }
-                    } label: {
-                        EmptyView()
-                    }
-                } label: {
-                    OptionButton(image: Image(systemName: self.model.filter.filterTarget.icon),
-                                 isActive: self.model.filter.filterTarget != .all)
-                }
-                .accessibilityLabel(self.model.filter.filterMatching == .regex
-                    ? String(format: "a11y_filterRow_targetLabel"~, self.model.filter.filterTarget.name) + ", " + String(format: "a11y_filterRow_matchLabel"~, FilterMatching.regex.name)
-                    : String(format: "a11y_filterRow_targetLabel"~, self.model.filter.filterTarget.name))
-
-                if self.model.filter.filterMatching != .regex {
-                    Menu {
-                        Picker(selection: Binding(
-                            get: { self.model.filter.filterMatching },
-                            set: { self.model.updateFilter(filterMatching: $0) }
-                        )) {
-                            ForEach(FilterMatching.allCases.filter { $0 != .regex }) { filterMatching in
-                                Label(filterMatching.name, systemImage: filterMatching.icon)
-                                    .tag(filterMatching)
-                            }
-                        } label: {
-                            EmptyView()
-                        }
-                    } label: {
-                        OptionButton(image: Image(systemName: self.model.filter.filterMatching.icon),
-                                     isActive: self.model.filter.filterMatching == .exact)
-                    }
-                    .accessibilityLabel(String(format: "a11y_filterRow_matchLabel"~, self.model.filter.filterMatching.name))
-
-                    Menu {
-                        Picker(selection: Binding(
-                            get: { self.model.filter.filterCase },
-                            set: { self.model.updateFilter(filterCase: $0) }
-                        )) {
-                            ForEach(FilterCase.allCases) { filterCase in
-                                Label(filterCase.name, systemImage: filterCase.icon)
-                                    .tag(filterCase)
-                            }
-                        } label: {
-                            EmptyView()
-                        }
-                    } label: {
-                        OptionButton(image: Image(systemName: self.model.filter.filterCase.icon),
-                                     isActive: self.model.filter.filterCase == .caseSensitive)
-                    }
-                    .accessibilityLabel(String(format: "a11y_filterRow_caseLabel"~, self.model.filter.filterCase.name))
-                }
-            }
-
-            if !self.isEditingText && self.model.filter.filterType.supportsFolders {
-                Menu {
-                    Picker(selection: Binding(
-                        get: { self.model.filter.denyFolderType },
-                        set: { self.model.updateFilter(denyFolder: $0) }
-                    )) {
-                        ForEach(DenyFolderType.allCases) { folder in
-                            Label(folder.name, systemImage: folder.iconName)
-                                .tag(folder)
-                        }
-                    } label: {
-                        EmptyView()
-                    }
-                } label: {
-                    OptionButton(image: Image(systemName: self.model.filter.denyFolderType.iconName), isActive: true)
-                }
-                .accessibilityLabel(String(format: "a11y_filterRow_folderLabel"~, self.model.filter.denyFolderType.name))
-            }
-        }  // HStack
-        .accessibilityElement(children: .contain)
+        }
     }
 
     @ViewBuilder
-    private func OptionButton(image: Image, isActive: Bool) -> some View {
-        image
-            .resizable()
-            .aspectRatio(contentMode: .fit)
-            .foregroundStyle(isActive ? AnyShapeStyle(.tint) : AnyShapeStyle(.secondary))
-            .frame(width: optionIconSize, height: optionIconSize)
-            .padding(7)
-            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
-            .overlay(
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .strokeBorder(Color.primary.opacity(0.12), lineWidth: 0.5)
-            )
+    private var optionButtons: some View {
+        HStack(spacing: 4) {
+            if self.model.filter.filterType.supportsAdvancedOptions {
+                targetMenu
+                if self.model.filter.filterMatching != .regex {
+                    matchingMenu
+                    caseMenu
+                }
+            }
+            if self.model.filter.filterType.supportsFolders {
+                folderMenu
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var targetMenu: some View {
+        Menu {
+            Picker(selection: Binding(
+                get: { self.model.filter.filterTarget },
+                set: { self.model.updateFilter(filterTarget: $0) }
+            )) {
+                ForEach(FilterTarget.allCases) { filterTarget in
+                    Label(filterTarget.name, systemImage: filterTarget.icon)
+                        .tag(filterTarget)
+                }
+            } label: {
+                EmptyView()
+            }
+        } label: {
+            FilterRowOptionChip(systemName: self.model.filter.filterTarget.icon,
+                                isActive: self.model.filter.filterTarget != .all)
+        }
+        .accessibilityLabel(self.model.filter.filterMatching == .regex
+            ? String(format: "a11y_filterRow_targetLabel"~, self.model.filter.filterTarget.name) + ", " + String(format: "a11y_filterRow_matchLabel"~, FilterMatching.regex.name)
+            : String(format: "a11y_filterRow_targetLabel"~, self.model.filter.filterTarget.name))
+    }
+
+    @ViewBuilder
+    private var matchingMenu: some View {
+        Menu {
+            Picker(selection: Binding(
+                get: { self.model.filter.filterMatching },
+                set: { self.model.updateFilter(filterMatching: $0) }
+            )) {
+                ForEach(FilterMatching.allCases.filter { $0 != .regex }) { filterMatching in
+                    Label(filterMatching.name, systemImage: filterMatching.icon)
+                        .tag(filterMatching)
+                }
+            } label: {
+                EmptyView()
+            }
+        } label: {
+            FilterRowOptionChip(systemName: self.model.filter.filterMatching.icon,
+                                isActive: self.model.filter.filterMatching == .exact)
+        }
+        .accessibilityLabel(String(format: "a11y_filterRow_matchLabel"~, self.model.filter.filterMatching.name))
+    }
+
+    @ViewBuilder
+    private var caseMenu: some View {
+        Menu {
+            Picker(selection: Binding(
+                get: { self.model.filter.filterCase },
+                set: { self.model.updateFilter(filterCase: $0) }
+            )) {
+                ForEach(FilterCase.allCases) { filterCase in
+                    Label(filterCase.name, systemImage: filterCase.icon)
+                        .tag(filterCase)
+                }
+            } label: {
+                EmptyView()
+            }
+        } label: {
+            FilterRowOptionChip(systemName: self.model.filter.filterCase.icon,
+                                isActive: self.model.filter.filterCase == .caseSensitive)
+        }
+        .accessibilityLabel(String(format: "a11y_filterRow_caseLabel"~, self.model.filter.filterCase.name))
+    }
+
+    @ViewBuilder
+    private var folderMenu: some View {
+        Menu {
+            Picker(selection: Binding(
+                get: { self.model.filter.denyFolderType },
+                set: { self.model.updateFilter(denyFolder: $0) }
+            )) {
+                ForEach(DenyFolderType.allCases) { folder in
+                    Label(folder.name, systemImage: folder.iconName)
+                        .tag(folder)
+                }
+            } label: {
+                EmptyView()
+            }
+        } label: {
+            FilterRowOptionChip(systemName: self.model.filter.denyFolderType.iconName, isActive: true)
+        }
+        .accessibilityLabel(String(format: "a11y_filterRow_folderLabel"~, self.model.filter.denyFolderType.name))
     }
 }
 

--- a/Simply Filter SMS/View Layer/Others/FooterView.swift
+++ b/Simply Filter SMS/View Layer/Others/FooterView.swift
@@ -11,29 +11,27 @@ struct FooterView: View {
     var onTap: (() ->())? = nil
 
     var body: some View {
-        VStack(spacing: 0) {
-            Spacer(minLength: 0)
-            Button {
-                self.onTap?()
-            } label: {
-                VStack (alignment: .center, spacing: 0) {
-                    Rectangle()
-                        .frame(height: 1, alignment: .bottom)
-                        .foregroundColor(.primary.opacity(0.05))
-                        .padding(.bottom, 8)
-                    Text("Simply Filter SMS v\(Text(appVersion))\n\(Text(String(format: "general_copyright"~, Calendar.current.component(.year, from: Date()))))")
-                        .frame(maxWidth: .infinity, alignment: .center)
-                        .font(.footnote)
-                        .foregroundColor(.primary)
-                        .multilineTextAlignment(.center)
-                }
-                .frame(maxWidth: .infinity)
-                .modifier(FooterBackground())
-                .contentShape(Rectangle())
+        Button {
+            self.onTap?()
+        } label: {
+            VStack (alignment: .center, spacing: 0) {
+                Rectangle()
+                    .frame(height: 1, alignment: .bottom)
+                    .foregroundColor(.primary.opacity(0.05))
+                    .padding(.bottom, 8)
+                Text("Simply Filter SMS v\(Text(appVersion))\n\(Text(String(format: "general_copyright"~, Calendar.current.component(.year, from: Date()))))")
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .font(.footnote)
+                    .foregroundColor(.primary)
+                    .multilineTextAlignment(.center)
+                    .dynamicTypeSize(...DynamicTypeSize.xxxLarge)
             }
-            .buttonStyle(.plain)
-            .accessibilityHint("a11y_footer_hint"~)
+            .frame(maxWidth: .infinity)
+            .modifier(FooterBackground())
+            .contentShape(Rectangle())
         }
+        .buttonStyle(.plain)
+        .accessibilityHint("a11y_footer_hint"~)
     }
 }
 

--- a/Simply Filter SMS/View Layer/Others/NotificationView.swift
+++ b/Simply Filter SMS/View Layer/Others/NotificationView.swift
@@ -350,7 +350,7 @@ private struct NotificationGlassBackground: ViewModifier {
     func body(content: Content) -> some View {
         if #available(iOS 26.0, *) {
             content
-                .glassEffect(.clear, in: shape)
+                .glassEffect(.regular, in: shape)
                 .containerShape(shape)
         } else {
             content

--- a/Simply Filter SMS/View Layer/Others/NotificationView.swift
+++ b/Simply Filter SMS/View Layer/Others/NotificationView.swift
@@ -11,66 +11,21 @@ import Foundation
 
 struct NotificationView: View {
 
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.needsStackedLayout) private var needsStackedLayout
     @ObservedObject var model: ViewModel
-    @State private var offset: CGFloat = -200
-
-    private let kHideOffset: CGFloat = -200
-    private let kShowOffset: CGFloat = 25
 
     var body: some View {
-        HStack (alignment: .center, spacing: 8) {
-            Image(systemName: self.model.icon)
-                .font(.body)
-                .padding(EdgeInsets(top: 8, leading: 10, bottom: 8, trailing: 0))
-                .foregroundStyle(self.model.iconColor)
-
-            VStack (alignment: .leading, spacing: 0) {
-                Text(self.model.title)
-                    .font(.caption.bold())
-                    .foregroundColor(.primary)
-
-                Text(self.model.subtitle)
-                    .font(.caption)
-                    .foregroundColor(.secondary)
+        Group {
+            if needsStackedLayout {
+                accessibilityLayout
+            } else {
+                compactLayout
             }
-            .padding(EdgeInsets(top: 4, leading: 0, bottom: 4, trailing: 4))
-
-            Button {
-                self.model.onButtonTap?()
-            } label: {
-                Text(self.model.buttonTitle)
-                    .font(.caption.bold())
-                    .foregroundColor(.primary)
-                    .padding(EdgeInsets(top: 6, leading: 8, bottom: 6, trailing: 8))
-                    .modifier(NotificationActionChipBackground())
-            }
-            .modifier(NotificationActionButtonStyle())
-            .padding(EdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8))
         }
+        .limitedDynamicTypeSize(.accessibility1)
         .accessibilityElement(children: .combine)
         .modifier(NotificationGlassBackground())
-        .gesture(
-            DragGesture(minimumDistance: 20, coordinateSpace: .global)
-                .onChanged({ value in
-                    let horizontalAmount = value.translation.width as CGFloat
-                    let verticalAmount = value.translation.height as CGFloat
-
-                    if abs(horizontalAmount) < abs(verticalAmount) && verticalAmount < -20  {
-                        self.model.onButtonTap?()
-                    }
-                })
-                .onEnded { value in
-                    let horizontalAmount = value.translation.width as CGFloat
-                    let verticalAmount = value.translation.height as CGFloat
-
-                    if abs(horizontalAmount) < abs(verticalAmount) && verticalAmount < 0  {
-                        self.model.onButtonTap?()
-                    }
-                })
-        .offset(y: self.offset)
-        .accessibilityHidden(offset != kShowOffset)
-        .animation(reduceMotion ? nil : .interpolatingSpring(mass: 1, stiffness: 200, damping: 30, initialVelocity: offset == kShowOffset ? 25 : 0), value: offset)
+        .gesture(dismissDragGesture)
         .onTapGesture {
             if let onTap = self.model.onTap {
                 onTap()
@@ -78,30 +33,99 @@ struct NotificationView: View {
                 self.model.onButtonTap?()
             }
         }
-        .onReceive(model.$show) { show in
-            withAnimation {
-                self.setShow(show)
+        .onChange(of: model.show) { show in
+            if show {
+                UINotificationFeedbackGenerator().notificationOccurred(.success)
+                if UIAccessibility.isVoiceOverRunning {
+                    UIAccessibility.post(
+                        notification: .announcement,
+                        argument: "\(self.model.title). \(self.model.subtitle)"
+                    )
+                }
+            } else {
+                let callback = self.model.onHide
+                self.model.onHide = nil
+                callback?()
             }
         }
     }
 
-    private func setShow(_ show: Bool) {
-        if show && self.offset == kHideOffset {
-            self.offset = kShowOffset
-            UINotificationFeedbackGenerator().notificationOccurred(.success)
-            if UIAccessibility.isVoiceOverRunning {
-                UIAccessibility.post(
-                    notification: .announcement,
-                    argument: "\(self.model.title). \(self.model.subtitle)"
-                )
+    private var compactLayout: some View {
+        HStack(alignment: .center, spacing: 8) {
+            notificationIcon
+            textColumn
+            actionButton
+        }
+    }
+
+    private var accessibilityLayout: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .top, spacing: 8) {
+                notificationIcon
+                textColumn
             }
+            actionButton
+                .frame(maxWidth: .infinity, alignment: .trailing)
         }
-        else if !show && self.offset == kShowOffset {
-            self.offset = kHideOffset
-            let callback = self.model.onHide
-            self.model.onHide = nil
-            callback?()
+    }
+
+    private var notificationIcon: some View {
+        Image(systemName: self.model.icon)
+            .font(.body)
+            .padding(EdgeInsets(top: 8, leading: 10, bottom: 8, trailing: 0))
+            .foregroundStyle(self.model.iconColor)
+    }
+
+    private var textColumn: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(self.model.title)
+                .font(.caption.bold())
+                .foregroundColor(.primary)
+
+            Text(self.model.subtitle)
+                .font(.caption)
+                .foregroundColor(.secondary)
         }
+        .padding(EdgeInsets(top: 4, leading: 0, bottom: 4, trailing: 4))
+        .if(needsStackedLayout) { content in
+            content
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private var actionButton: some View {
+        Button {
+            self.model.onButtonTap?()
+        } label: {
+            Text(self.model.buttonTitle)
+                .font(.caption.bold())
+                .foregroundColor(.primary)
+                .padding(EdgeInsets(top: 6, leading: 8, bottom: 6, trailing: 8))
+                .modifier(NotificationActionChipBackground())
+        }
+        .modifier(NotificationActionButtonStyle())
+        .padding(EdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8))
+    }
+
+    private var dismissDragGesture: some Gesture {
+        DragGesture(minimumDistance: 20, coordinateSpace: .global)
+            .onChanged { value in
+                let horizontalAmount = value.translation.width
+                let verticalAmount = value.translation.height
+
+                if abs(horizontalAmount) < abs(verticalAmount) && verticalAmount < -20 {
+                    self.model.onButtonTap?()
+                }
+            }
+            .onEnded { value in
+                let horizontalAmount = value.translation.width
+                let verticalAmount = value.translation.height
+
+                if abs(horizontalAmount) < abs(verticalAmount) && verticalAmount < 0 {
+                    self.model.onButtonTap?()
+                }
+            }
     }
 
     class ViewModel: ObservableObject {

--- a/Simply Filter SMS/View Layer/Others/NotificationView.swift
+++ b/Simply Filter SMS/View Layer/Others/NotificationView.swift
@@ -11,8 +11,13 @@ import Foundation
 
 struct NotificationView: View {
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.needsStackedLayout) private var needsStackedLayout
     @ObservedObject var model: ViewModel
+    @State private var offset: CGFloat = -200
+
+    private let kHideOffset: CGFloat = -200
+    private let kShowOffset: CGFloat = 25
 
     var body: some View {
         Group {
@@ -26,6 +31,9 @@ struct NotificationView: View {
         .accessibilityElement(children: .combine)
         .modifier(NotificationGlassBackground())
         .gesture(dismissDragGesture)
+        .offset(y: self.offset)
+        .accessibilityHidden(offset != kShowOffset)
+        .animation(reduceMotion ? nil : .interpolatingSpring(mass: 1, stiffness: 200, damping: 30, initialVelocity: offset == kShowOffset ? 25 : 0), value: offset)
         .onTapGesture {
             if let onTap = self.model.onTap {
                 onTap()
@@ -33,20 +41,29 @@ struct NotificationView: View {
                 self.model.onButtonTap?()
             }
         }
-        .onChange(of: model.show) { show in
-            if show {
-                UINotificationFeedbackGenerator().notificationOccurred(.success)
-                if UIAccessibility.isVoiceOverRunning {
-                    UIAccessibility.post(
-                        notification: .announcement,
-                        argument: "\(self.model.title). \(self.model.subtitle)"
-                    )
-                }
-            } else {
-                let callback = self.model.onHide
-                self.model.onHide = nil
-                callback?()
+        .onReceive(model.$show) { show in
+            withAnimation {
+                self.setShow(show)
             }
+        }
+    }
+
+    private func setShow(_ show: Bool) {
+        if show && self.offset == kHideOffset {
+            self.offset = kShowOffset
+            UINotificationFeedbackGenerator().notificationOccurred(.success)
+            if UIAccessibility.isVoiceOverRunning {
+                UIAccessibility.post(
+                    notification: .announcement,
+                    argument: "\(self.model.title). \(self.model.subtitle)"
+                )
+            }
+        }
+        else if !show && self.offset == kShowOffset {
+            self.offset = kHideOffset
+            let callback = self.model.onHide
+            self.model.onHide = nil
+            callback?()
         }
     }
 

--- a/Simply Filter SMS/View Layer/Others/TestFilterResultRow.swift
+++ b/Simply Filter SMS/View Layer/Others/TestFilterResultRow.swift
@@ -18,16 +18,17 @@ struct TestFilterResultRow: View {
     @ScaledMetric(relativeTo: .body) private var titleSize: CGFloat = 16
 
     var body: some View {
-        HStack(alignment: .center, spacing: 0) {
+        AdaptiveRow {
             Image(systemName: style.icon)
                 .foregroundColor(style.color)
                 .frame(width: iconSize, alignment: .center)
                 .accessibilityHidden(true)
-
+        } content: {
             VStack(alignment: .leading, spacing: 2) {
                 Text(style.title)
                     .font(.system(size: titleSize, weight: .heavy))
                     .foregroundColor(style.color)
+                    .fixedSize(horizontal: false, vertical: true)
 
                 if let caption = Self.caption(for: result.match) {
                     caption
@@ -35,9 +36,6 @@ struct TestFilterResultRow: View {
                         .foregroundColor(.secondary)
                 }
             }
-            .padding(.leading, 8)
-
-            Spacer(minLength: 0)
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel(Self.accessibilityText(for: result))
@@ -99,9 +97,11 @@ private struct TestResultStyle {
 #Preview("Junk") {
     TestFilterResultRow(result: MessageEvaluationResult(action: .junk, match: .userFilter("amazon")))
         .padding()
+        .adaptiveLayoutEnvironment()
 }
 
 #Preview("Allowed") {
     TestFilterResultRow(result: MessageEvaluationResult(action: .allow, match: .noMatch))
         .padding()
+        .adaptiveLayoutEnvironment()
 }

--- a/Simply Filter SMS/View Layer/Others/ViewModfiers.swift
+++ b/Simply Filter SMS/View Layer/Others/ViewModfiers.swift
@@ -11,16 +11,33 @@ import SwiftUI
 struct EmbeddedFooterView: ViewModifier {
     var isHidden: Bool = false
     var onTap: (() ->())? = nil
-    
+
+    @Environment(\.needsStackedLayout) private var needsStackedLayout
+
     func body(content: Content) -> some View {
-        ZStack (alignment: .bottom) {
-            content
-                .accessibilitySortPriority(1)
-            if !isHidden {
-                FooterView(onTap: onTap)
-                    .ignoresSafeArea(.keyboard, edges: .all)
-                    .allowsHitTesting(!ProcessInfo.processInfo.isInTestingMode)
+        Group {
+            if needsStackedLayout {
+                content
+                    .accessibilitySortPriority(1)
+                    .safeAreaInset(edge: .bottom, spacing: 0) {
+                        footerContent
+                    }
+            } else {
+                ZStack(alignment: .bottom) {
+                    content
+                        .accessibilitySortPriority(1)
+                    footerContent
+                }
             }
+        }
+    }
+
+    @ViewBuilder
+    private var footerContent: some View {
+        if !isHidden {
+            FooterView(onTap: onTap)
+                .ignoresSafeArea(.keyboard, edges: .all)
+                .allowsHitTesting(!ProcessInfo.processInfo.isInTestingMode)
         }
     }
 }
@@ -50,12 +67,54 @@ struct EmbeddedCloseButton: ViewModifier {
 }
 
 struct EmbeddedNotificationView: ViewModifier {
-    var model: NotificationView.ViewModel
-    
+    @ObservedObject var model: NotificationView.ViewModel
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.needsStackedLayout) private var needsStackedLayout
+
+    private let compactTopPadding: CGFloat = 25
+
     func body(content: Content) -> some View {
-        ZStack (alignment: .top) {
-            content
-            NotificationView(model: model)
+        Group {
+            if needsStackedLayout {
+                content
+                    .safeAreaInset(edge: .top, spacing: 0) {
+                        notificationInsetContent
+                    }
+            } else {
+                ZStack(alignment: .top) {
+                    content
+                    notificationOverlayContent
+                }
+            }
+        }
+        .animation(reduceMotion ? nil : .interpolatingSpring(mass: 1, stiffness: 200, damping: 30), value: model.show)
+    }
+
+    @ViewBuilder
+    private var notificationInsetContent: some View {
+        if model.show {
+            HStack {
+                Spacer(minLength: 0)
+                NotificationView(model: model)
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 8)
+            .padding(.bottom, 4)
+            .transition(.move(edge: .top).combined(with: .opacity))
+        }
+    }
+
+    @ViewBuilder
+    private var notificationOverlayContent: some View {
+        if model.show {
+            HStack {
+                Spacer(minLength: 0)
+                NotificationView(model: model)
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 8)
+            .padding(.top, compactTopPadding)
+            .transition(.move(edge: .top).combined(with: .opacity))
         }
     }
 }

--- a/Simply Filter SMS/View Layer/Others/ViewModfiers.swift
+++ b/Simply Filter SMS/View Layer/Others/ViewModfiers.swift
@@ -67,54 +67,12 @@ struct EmbeddedCloseButton: ViewModifier {
 }
 
 struct EmbeddedNotificationView: ViewModifier {
-    @ObservedObject var model: NotificationView.ViewModel
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @Environment(\.needsStackedLayout) private var needsStackedLayout
-
-    private let compactTopPadding: CGFloat = 25
+    var model: NotificationView.ViewModel
 
     func body(content: Content) -> some View {
-        Group {
-            if needsStackedLayout {
-                content
-                    .safeAreaInset(edge: .top, spacing: 0) {
-                        notificationInsetContent
-                    }
-            } else {
-                ZStack(alignment: .top) {
-                    content
-                    notificationOverlayContent
-                }
-            }
-        }
-        .animation(reduceMotion ? nil : .interpolatingSpring(mass: 1, stiffness: 200, damping: 30), value: model.show)
-    }
-
-    @ViewBuilder
-    private var notificationInsetContent: some View {
-        if model.show {
-            HStack {
-                Spacer(minLength: 0)
-                NotificationView(model: model)
-                Spacer(minLength: 0)
-            }
-            .padding(.horizontal, 8)
-            .padding(.bottom, 4)
-            .transition(.move(edge: .top).combined(with: .opacity))
-        }
-    }
-
-    @ViewBuilder
-    private var notificationOverlayContent: some View {
-        if model.show {
-            HStack {
-                Spacer(minLength: 0)
-                NotificationView(model: model)
-                Spacer(minLength: 0)
-            }
-            .padding(.horizontal, 8)
-            .padding(.top, compactTopPadding)
-            .transition(.move(edge: .top).combined(with: .opacity))
+        ZStack(alignment: .top) {
+            content
+            NotificationView(model: model)
         }
     }
 }

--- a/Simply Filter SMS/View Layer/Screens/AboutView.swift
+++ b/Simply Filter SMS/View Layer/Screens/AboutView.swift
@@ -31,18 +31,19 @@ struct AboutView: View {
             List {
                 // Identity
                 Section {
-                    HStack(spacing: 14) {
+                    AdaptiveRow(compactSpacing: 14) {
                         Image("logo")
                             .resizable()
                             .aspectRatio(contentMode: .fit)
                             .frame(width: cardLogoSize, height: cardLogoSize)
                             .clipShape(RoundedRectangle(cornerRadius: cardLogoSize * 0.225, style: .continuous))
                             .accessibilityHidden(true)
-
+                    } content: {
                         VStack(alignment: .leading, spacing: 6) {
                             Text("Simply Filter SMS")
                                 .font(.title2.bold())
                                 .foregroundColor(.primary)
+                                .fixedSize(horizontal: false, vertical: true)
 
                             Button {
                                 model.setClipboard(content: "v\(appVersion) (\(appBuild))", displayName: "a11y_about_versionCopied"~)

--- a/Simply Filter SMS/View Layer/Screens/AddFilterView.swift
+++ b/Simply Filter SMS/View Layer/Screens/AddFilterView.swift
@@ -28,8 +28,10 @@ struct AddFilterView: View {
                     Spacer()
 
                     HStack (alignment: .center) {
-
-                        ZStack(alignment: .leading) {
+                        AdaptiveRow {
+                            EmptyView()
+                        } content: {
+                            ZStack(alignment: .leading) {
                             if self.model.selectedFilterMatching == .regex {
                                 if self.model.filterText.isEmpty {
                                     Text("[A-Za-z0-9]+".highlightedAsRegex)
@@ -55,11 +57,12 @@ struct AddFilterView: View {
                                 .foregroundColor(self.model.selectedFilterMatching == .regex ? .clear : .primary)
                         }
                         .animation(.easeInOut(duration: 0.25), value: self.model.selectedFilterMatching)
-
-                        if self.model.isDuplicateFilter {
-                            FilterBadge(text: "addFilter_duplicate"~, color: .red, systemImage: "xmark.circle.fill")
-                        } else if self.model.isInvalidRegex {
-                            FilterBadge(text: "addFilter_invalidRegex"~, color: .red, systemImage: "xmark.circle.fill")
+                        } trailing: {
+                            if self.model.isDuplicateFilter {
+                                FilterBadge(text: "addFilter_duplicate"~, color: .red, systemImage: "xmark.circle.fill")
+                            } else if self.model.isInvalidRegex {
+                                FilterBadge(text: "addFilter_invalidRegex"~, color: .red, systemImage: "xmark.circle.fill")
+                            }
                         }
                     }
 
@@ -131,7 +134,9 @@ struct AddFilterView: View {
                                     .italic()
                                     .bold()
 
-                                HStack {
+                                AdaptiveRow {
+                                    EmptyView()
+                                } content: {
                                     TextField("addFilter_regexTestPlaceholder"~, text: $model.regexTestText)
                                         .focused($focusedField, equals: .regexTest)
                                         .onSubmit {
@@ -144,7 +149,7 @@ struct AddFilterView: View {
                                                 break
                                             }
                                         }
-
+                                } trailing: {
                                     switch self.model.regexTestResult {
                                     case .match:
                                         FilterBadge(text: "addFilter_regexMatch"~, color: .green, systemImage: "checkmark.circle.fill")

--- a/Simply Filter SMS/View Layer/Screens/AppHomeView.swift
+++ b/Simply Filter SMS/View Layer/Screens/AppHomeView.swift
@@ -42,7 +42,7 @@ struct AppHomeView: View, ViewWithPersistentStoreReload {
                 Section {
                     let screen: Screen = .automaticBlocking
                     
-                    AdaptiveRow(compactAlignment: .top) {
+                    AdaptiveRow {
                         Group {
                             if #available(iOS 17, *) {
                                 if self.model.isAutomaticFilteringOn && !self.model.isAllUnknownFilteringOn && !reduceMotion {

--- a/Simply Filter SMS/View Layer/Screens/AppHomeView.swift
+++ b/Simply Filter SMS/View Layer/Screens/AppHomeView.swift
@@ -42,60 +42,33 @@ struct AppHomeView: View, ViewWithPersistentStoreReload {
                 Section {
                     let screen: Screen = .automaticBlocking
                     
-                    HStack {
-                                Group {
-                                    if #available(iOS 17, *) {
-                                        if self.model.isAutomaticFilteringOn && !self.model.isAllUnknownFilteringOn && !reduceMotion {
-                                            ShieldGlintIcon()
-                                        } else {
-                                            Image(systemName: "bolt.shield.fill")
-                                                .symbolRenderingMode(.palette)
-                                                .foregroundStyle(Color.white.opacity(0.9), Color.indigo)
-                                        }
-                                    } else {
-                                        Image(systemName: "bolt.shield.fill")
-                                            .foregroundColor(.indigo)
-                                    }
+                    AdaptiveRow(compactAlignment: .top) {
+                        Group {
+                            if #available(iOS 17, *) {
+                                if self.model.isAutomaticFilteringOn && !self.model.isAllUnknownFilteringOn && !reduceMotion {
+                                    ShieldGlintIcon()
+                                } else {
+                                    Image(systemName: "bolt.shield.fill")
+                                        .symbolRenderingMode(.palette)
+                                        .foregroundStyle(Color.white.opacity(0.9), Color.indigo)
                                 }
-                                .font(.system(size: shieldIconSize))
-                                .padding(.trailing, 1)
-                                .accessibilityHidden(true)
-
-                                VStack (alignment: .leading) {
-                                    Text("autoFilter_title"~)
-                                        .font(.system(size: autoFilterTitleSize, weight: .bold, design: .rounded))
-
-                                    if !self.model.subtitle.isEmpty {
-                                        Text(self.model.subtitle)
-                                            .font(.caption2)
-                                            .lineLimit(2)
-                                    }
-                                }
-
-                                Spacer()
-
-                                if self.model.isAutomaticFilteringOn {
-                                    let onColor = model.customAccent ?? Color.green
-                                    Text("autoFilter_ON"~)
-                                        .padding(EdgeInsets(top: 4, leading: 8, bottom: 4, trailing: 8))
-                                        .background(onColor.opacity(0.1))
-                                        .foregroundColor(onColor)
-                                        .containerShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
-                                        .font(.system(size: badgeFontSize, weight: .heavy, design: .default))
-                                }
-                                else {
-                                    Text("autoFilter_OFF"~)
-                                        .padding(EdgeInsets(top: 4, leading: 4, bottom: 4, trailing: 4))
-                                        .background(Color.red.opacity(0.1))
-                                        .foregroundColor(.red)
-                                        .containerShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
-                                        .font(.system(size: badgeFontSize, weight: .heavy, design: .default))
-                                }
+                            } else {
+                                Image(systemName: "bolt.shield.fill")
+                                    .foregroundColor(.indigo)
                             }
-                            .padding(.vertical, 12)
-                            .sidebarNavigationRow(screen: screen, isRegular: horizontalSizeClass == .regular) {
-                                model.navigationScreen = screen
-                            }
+                        }
+                        .font(.system(size: shieldIconSize))
+                        .frame(width: shieldIconSize + 4, alignment: .center)
+                        .accessibilityHidden(true)
+                    } content: {
+                        automaticFilterTextColumn
+                    } trailing: {
+                        automaticFilterStatusBadge
+                    }
+                    .padding(.vertical, 12)
+                    .sidebarNavigationRow(screen: screen, isRegular: horizontalSizeClass == .regular) {
+                        model.navigationScreen = screen
+                    }
                         .listRowInsets(EdgeInsets(top: 0, leading: 11, bottom: 0, trailing: 20))
                         .listRowBackground(horizontalSizeClass == .regular ? (model.navigationScreen == screen ? Color.primary.opacity(0.08) : Color(UIColor.secondarySystemGroupedBackground)) : nil)
                         .accessibility(identifier: TestIdentifier.automaticFilterLink.rawValue)
@@ -112,84 +85,8 @@ struct AppHomeView: View, ViewWithPersistentStoreReload {
                     ForEach($model.rules.indices, id: \.self) { index in
                         let rule = model.rules[index].item
                         let isDisabled = self.model.isAllUnknownFilteringOn && rule != .allUnknown
-                        
-                        Toggle(isOn: $model.rules[index].state) {
-                            HStack {
-                                if rule.isTextIcon {
-                                    let ruleKey: String = rule.title
-                                    let baseEmoji = rule.icon
-                                    let currentEmoji = dynamicEmojis[ruleKey] ?? baseEmoji
-                                    Button {
-                                        dynamicEmojis[ruleKey] = EmojiGenerator.randomEmoji()
-                                    } label: {
-                                        Text(currentEmoji)
-                                            .opacity(isDisabled ? 0.5 : 1)
-                                            .frame(maxWidth: 20, maxHeight: .infinity, alignment: .center)
-                                            .font(.system(size: emojiIconSize))
-                                    }
-                                    .buttonStyle(.plain)
-                                    .disabled(isDisabled)
-                                }
-                                else {
-                                    Image(systemName: rule.icon)
-                                        .foregroundColor(rule.iconColor.opacity(isDisabled ? 0.5 : 1))
-                                        .frame(maxWidth: 20, maxHeight: .infinity, alignment: .center)
-                                        .font(rule.isDestructive ? Font.body.bold() : .body)
-                                }
-                                
-                                VStack (alignment: .leading, spacing: 0) {
-                                    let color = rule.isDestructive && model.rules[index].state ? Color.red : .primary
-                                    Text(rule.title)
-                                        .foregroundColor(color.opacity(isDisabled ? 0.5 : 1))
-                                    
-                                    if let subtitle = rule.subtitle,
-                                       let action = rule.action,
-                                       let actionTitle = rule.actionTitle {
 
-                                        HStack (alignment: .center, spacing: 4) {
-                                            Text(String(format: subtitle, self.model.shortSenderChoice))
-                                                .font(.caption2)
-                                                .foregroundColor(.secondary)
-
-                                            Menu {
-                                                Text(actionTitle)
-
-                                                Divider()
-
-                                                ForEach(3...6, id: \.self) { index in
-                                                    Button {
-                                                        self.model.setSelectedChoice(for: rule, choice: index)
-                                                    } label: {
-                                                        Text("\(index)")
-                                                    }
-                                                }
-                                            } label: {
-                                                Text(action)
-                                                    .font(.caption2)
-                                            }
-                                        }
-                                    } else if rule == .countryAllowlist && model.rules[index].state {
-                                        HStack (alignment: .center, spacing: 4) {
-                                            Text(self.model.selectedCountriesSummary)
-                                                .font(.caption2)
-                                                .foregroundColor(.secondary)
-                                                .lineLimit(1)
-
-                                            Button {
-                                                self.model.requestSheet(.countryList)
-                                            } label: {
-                                                Text("autoFilter_shortSender_change"~)
-                                                    .font(.caption2)
-                                                    .foregroundStyle(.tint)
-                                            }
-                                            .buttonStyle(.plain)
-                                            .accessibilityIdentifier(TestIdentifier.countryAllowlistButton.rawValue)
-                                        }
-                                    }
-                                }
-                                .padding(.leading, 8)
-                            }
-                        } // Toggle
+                        smartFilterToggle(index: index, rule: rule, isDisabled: isDisabled)
                         .if(rule.isDestructive) { $0.tint(.red) }
                         .disabled(isDisabled)
                         .listRowBackground(Color(UIColor.secondarySystemGroupedBackground))
@@ -211,21 +108,7 @@ struct AppHomeView: View, ViewWithPersistentStoreReload {
                 //MARK: User Filters
                 Section {
                     ForEach(FilterType.allCases.sorted(by: { $0.sortIndex < $1.sortIndex }), id: \.self) { filterType in
-                        HStack {
-                            Image(systemName: filterType.iconName)
-                                .foregroundColor(filterType.iconColor)
-                                .frame(maxWidth: 20, maxHeight: .infinity, alignment: .center)
-
-                            Text(filterType.name)
-                                .padding(.leading, 8)
-
-                            Spacer()
-
-                            Text(String.localizedStringWithFormat("general_active_count"~, self.model.activeCount(for: filterType)))
-                                .textCase(.uppercase)
-                                .foregroundColor(.secondary)
-                                .font(Font.caption2)
-                        }
+                        userFilterRow(filterType: filterType)
                         .sidebarNavigationRow(screen: filterType.screen, isRegular: horizontalSizeClass == .regular) {
                             model.navigationScreen = filterType.screen
                         }
@@ -336,7 +219,173 @@ struct AppHomeView: View, ViewWithPersistentStoreReload {
         }
         .optionalTint(model.customAccent)
     }
+
+    @ViewBuilder
+    private var automaticFilterTextColumn: some View {
+        VStack(alignment: .leading) {
+            Text("autoFilter_title"~)
+                .font(.system(size: autoFilterTitleSize, weight: .bold, design: .rounded))
+                .fixedSize(horizontal: false, vertical: true)
+
+            if !self.model.subtitle.isEmpty {
+                Text(self.model.subtitle)
+                    .font(.caption2)
+                    .lineLimit(3)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var automaticFilterStatusBadge: some View {
+        if self.model.isAutomaticFilteringOn {
+            let onColor = model.customAccent ?? Color.green
+            Text("autoFilter_ON"~)
+                .padding(EdgeInsets(top: 4, leading: 8, bottom: 4, trailing: 8))
+                .background(onColor.opacity(0.1))
+                .foregroundColor(onColor)
+                .containerShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
+                .font(.system(size: badgeFontSize, weight: .heavy, design: .default))
+                .limitedDynamicTypeSize()
+        } else {
+            Text("autoFilter_OFF"~)
+                .padding(EdgeInsets(top: 4, leading: 4, bottom: 4, trailing: 4))
+                .background(Color.red.opacity(0.1))
+                .foregroundColor(.red)
+                .containerShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
+                .font(.system(size: badgeFontSize, weight: .heavy, design: .default))
+                .limitedDynamicTypeSize()
+        }
+    }
     
+    @ViewBuilder
+    private func smartFilterToggle(index: Int, rule: RuleType, isDisabled: Bool) -> some View {
+        AdaptiveToggle(isOn: $model.rules[index].state) {
+            smartFilterLabel(index: index, rule: rule, isDisabled: isDisabled)
+        }
+    }
+
+    @ViewBuilder
+    private func smartFilterLabel(index: Int, rule: RuleType, isDisabled: Bool) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            smartFilterIcon(index: index, rule: rule, isDisabled: isDisabled)
+
+            smartFilterTextColumn(index: index, rule: rule, isDisabled: isDisabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    @ViewBuilder
+    private func smartFilterIcon(index: Int, rule: RuleType, isDisabled: Bool) -> some View {
+        if rule.isTextIcon {
+            let ruleKey: String = rule.title
+            let baseEmoji = rule.icon
+            let currentEmoji = dynamicEmojis[ruleKey] ?? baseEmoji
+            Button {
+                dynamicEmojis[ruleKey] = EmojiGenerator.randomEmoji()
+            } label: {
+                Text(currentEmoji)
+                    .opacity(isDisabled ? 0.5 : 1)
+                    .font(.system(size: emojiIconSize))
+            }
+            .buttonStyle(.plain)
+            .disabled(isDisabled)
+            .adaptiveIconColumn()
+        } else {
+            Image(systemName: rule.icon)
+                .foregroundColor(rule.iconColor.opacity(isDisabled ? 0.5 : 1))
+                .font(rule.isDestructive ? Font.body.bold() : .body)
+                .adaptiveIconColumn()
+        }
+    }
+
+    @ViewBuilder
+    private func smartFilterTextColumn(index: Int, rule: RuleType, isDisabled: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            let color = rule.isDestructive && model.rules[index].state ? Color.red : .primary
+            Text(rule.title)
+                .foregroundColor(color.opacity(isDisabled ? 0.5 : 1))
+                .fixedSize(horizontal: false, vertical: true)
+
+            if let subtitle = rule.subtitle,
+               let action = rule.action,
+               let actionTitle = rule.actionTitle {
+                smartFilterShortSenderControls(
+                    subtitle: String(format: subtitle, self.model.shortSenderChoice),
+                    action: action,
+                    actionTitle: actionTitle,
+                    rule: rule)
+            } else if rule == .countryAllowlist && model.rules[index].state {
+                countryAllowlistControls
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func smartFilterShortSenderControls(subtitle: String, action: String, actionTitle: String, rule: RuleType) -> some View {
+        AdaptiveFlowRow {
+            Text(subtitle)
+                .font(.caption2)
+                .foregroundColor(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Menu {
+                Text(actionTitle)
+                Divider()
+                ForEach(3...6, id: \.self) { choice in
+                    Button {
+                        self.model.setSelectedChoice(for: rule, choice: choice)
+                    } label: {
+                        Text("\(choice)")
+                    }
+                }
+            } label: {
+                Text(action)
+                    .font(.caption2)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var countryAllowlistControls: some View {
+        AdaptiveFlowRow {
+            Text(self.model.selectedCountriesSummary)
+                .font(.caption2)
+                .foregroundColor(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Button {
+                self.model.requestSheet(.countryList)
+            } label: {
+                Text("autoFilter_shortSender_change"~)
+                    .font(.caption2)
+                    .foregroundStyle(.tint)
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier(TestIdentifier.countryAllowlistButton.rawValue)
+        }
+    }
+
+    @ViewBuilder
+    private func userFilterRow(filterType: FilterType) -> some View {
+        let activeCount = String.localizedStringWithFormat("general_active_count"~, self.model.activeCount(for: filterType))
+
+        AdaptiveRow {
+            Image(systemName: filterType.iconName)
+                .foregroundColor(filterType.iconColor)
+                .adaptiveIconColumn()
+        } content: {
+            Text(filterType.name)
+                .fixedSize(horizontal: false, vertical: true)
+        } trailing: {
+            Text(activeCount)
+                .textCase(.uppercase)
+                .foregroundColor(.secondary)
+                .font(.caption2)
+                .limitedDynamicTypeSize()
+        }
+    }
+
     @ViewBuilder
     private func NavigationBarTrailingItem() -> some View {
         Menu {

--- a/Simply Filter SMS/View Layer/Screens/CountryListView.swift
+++ b/Simply Filter SMS/View Layer/Screens/CountryListView.swift
@@ -87,11 +87,12 @@ struct CountryListView: View {
         Button {
             model.toggleSelection(entry)
         } label: {
-            HStack {
+            AdaptiveRow(stackedTrailingAlignment: .trailing, compactAlignment: .top) {
                 Text(entry.flagEmoji)
                     .font(.title2)
                     .accessibilityHidden(true)
-
+                    .adaptiveIconColumn(width: 36)
+            } content: {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(entry.displayName)
                         .foregroundColor(.primary)
@@ -99,9 +100,7 @@ struct CountryListView: View {
                         .font(.caption)
                         .foregroundColor(.secondary)
                 }
-
-                Spacer()
-
+            } trailing: {
                 if model.isSelected(entry) {
                     Image(systemName: "checkmark")
                         .foregroundStyle(.tint)

--- a/Simply Filter SMS/View Layer/Screens/CountryListView.swift
+++ b/Simply Filter SMS/View Layer/Screens/CountryListView.swift
@@ -87,7 +87,7 @@ struct CountryListView: View {
         Button {
             model.toggleSelection(entry)
         } label: {
-            AdaptiveRow(stackedTrailingAlignment: .trailing, compactAlignment: .top) {
+            AdaptiveRow(stackedTrailingAlignment: .trailing) {
                 Text(entry.flagEmoji)
                     .font(.title2)
                     .accessibilityHidden(true)

--- a/Simply Filter SMS/View Layer/Screens/FilterListView.swift
+++ b/Simply Filter SMS/View Layer/Screens/FilterListView.swift
@@ -50,25 +50,14 @@ struct FilterListView: View, ViewWithPersistentStoreReload {
                 .deleteDisabled(self.model.editMode.isEditing)
             } header: {
                 if self.model.regularFilters.count > 0 {
-                    HStack {
-                        Text(self.model.filterType == .denyLanguage ? "general_lang"~ : "filterList_text"~)
-
-                        Spacer()
-
-                        Text(self.model.filterType.supportsAdvancedOptions ? "filterList_options"~ : "filterList_folder"~)
-                            .padding(.trailing, 8)
-                    }
+                    AdaptiveColumnHeader(
+                        leading: self.model.filterType == .denyLanguage ? "general_lang"~ : "filterList_text"~,
+                        trailing: self.model.filterType.supportsAdvancedOptions ? "filterList_options"~ : "filterList_folder"~,
+                        trailingSecondary: false)
                 }
             } footer: {
                 if self.model.regexFilters.isEmpty {
-                    VStack {
-                        Text(.init(self.model.footer))
-
-                        Spacer()
-
-                        AddFilterButton()
-                            .padding(.top, self.model.filters.count > 0 ? 0 : 120)
-                    }
+                    listFooter
                 }
             }
 
@@ -90,14 +79,7 @@ struct FilterListView: View, ViewWithPersistentStoreReload {
                 } header: {
                     Text("addFilter_match_regex"~)
                 } footer: {
-                    VStack {
-                        Text(.init(self.model.footer))
-
-                        Spacer()
-
-                        AddFilterButton()
-                            .padding(.top, self.model.filters.count > 0 ? 0 : 120)
-                    }
+                    listFooter
                 }
             }
         } // List
@@ -146,6 +128,16 @@ struct FilterListView: View, ViewWithPersistentStoreReload {
         }
         } // ScrollViewReader
         .modifier(persistentStoreReload)
+    }
+
+    @ViewBuilder
+    private var listFooter: some View {
+        VStack(spacing: 16) {
+            Text(.init(self.model.footer))
+
+            AddFilterButton()
+        }
+        .padding(.top, self.model.filters.count == 0 ? 40 : 0)
     }
     
     @ViewBuilder
@@ -239,9 +231,9 @@ struct FilterListView: View, ViewWithPersistentStoreReload {
                     Spacer()
                 }
                 .contentShape(Rectangle())
-                .frame(minWidth: 1, maxWidth: .infinity, maxHeight: .infinity)
+                .frame(maxWidth: .infinity)
                 .padding(.top, 1)
-                .padding(.bottom, 40)
+                .padding(.bottom, 16)
             }
             .highPriorityGesture(TapGesture()
                 .onEnded({ _ in

--- a/Simply Filter SMS/View Layer/Screens/FilterTransferPreviewView.swift
+++ b/Simply Filter SMS/View Layer/Screens/FilterTransferPreviewView.swift
@@ -180,7 +180,7 @@ struct FilterTransferCandidateListView: View {
                 .foregroundColor(.primary)
                 .fixedSize(horizontal: false, vertical: true)
         } trailing: {
-            HStack(spacing: 4) {
+            HStack {
                 if candidate.type.supportsAdvancedOptions {
                     FilterRowOptionChip(systemName: candidate.filterTarget.icon,
                                         isActive: candidate.filterTarget != .all)

--- a/Simply Filter SMS/View Layer/Screens/FilterTransferPreviewView.swift
+++ b/Simply Filter SMS/View Layer/Screens/FilterTransferPreviewView.swift
@@ -16,7 +16,6 @@ struct FilterTransferPreviewView: View {
     var dismiss
 
     @StateObject var model: ViewModel
-    @ScaledMetric(relativeTo: .body) private var typeIconSize: CGFloat = 20
 
     init(model: ViewModel) {
         _model = StateObject(wrappedValue: model)
@@ -32,30 +31,7 @@ struct FilterTransferPreviewView: View {
                         NavigationLink {
                             FilterTransferCandidateListView(model: self.model, filterType: filterType)
                         } label: {
-                            HStack {
-                                Image(systemName: filterType.iconName)
-                                    .foregroundColor(filterType.iconColor)
-                                    .frame(maxWidth: typeIconSize, maxHeight: .infinity, alignment: .center)
-
-                                VStack(alignment: .leading, spacing: 0) {
-                                    Text(filterType.name)
-                                        .padding(.leading, 8)
-
-                                    if self.model.willForceClear(filterType) {
-                                        Text("\(Image(systemName: "exclamationmark.triangle.fill")) \("importFilters_willClear"~)")
-                                            .font(.caption2)
-                                            .foregroundColor(.red)
-                                            .padding(.leading, 8)
-                                    }
-                                }
-
-                                Spacer()
-
-                                Text(String.localizedStringWithFormat("general_active_count"~, self.model.selectedCount(for: filterType)))
-                                    .textCase(.uppercase)
-                                    .foregroundColor(.secondary)
-                                    .font(Font.caption2)
-                            }
+                            filterTypeRow(filterType)
                         }
                         .accentColor(Color.primary.opacity(0.35))
                         .disabled(self.model.candidates(for: filterType).isEmpty)
@@ -109,6 +85,36 @@ struct FilterTransferPreviewView: View {
             ShareSheet(items: [file.url])
         }
     }
+
+    @ViewBuilder
+    private func filterTypeRow(_ filterType: FilterType) -> some View {
+        let activeCount = String.localizedStringWithFormat("general_active_count"~, self.model.selectedCount(for: filterType))
+
+        AdaptiveRow {
+            Image(systemName: filterType.iconName)
+                .foregroundColor(filterType.iconColor)
+                .adaptiveIconColumn()
+        } content: {
+            VStack(alignment: .leading, spacing: 0) {
+                Text(filterType.name)
+                    .padding(.leading, 8)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                if self.model.willForceClear(filterType) {
+                    Text("\(Image(systemName: "exclamationmark.triangle.fill")) \("importFilters_willClear"~)")
+                        .font(.caption2)
+                        .foregroundColor(.red)
+                        .padding(.leading, 8)
+                }
+            }
+        } trailing: {
+            Text(activeCount)
+                .textCase(.uppercase)
+                .foregroundColor(.secondary)
+                .font(Font.caption2)
+                .limitedDynamicTypeSize()
+        }
+    }
 }
 
 
@@ -118,8 +124,6 @@ struct FilterTransferCandidateListView: View {
     @ObservedObject var model: FilterTransferPreviewView.ViewModel
     let filterType: FilterType
 
-    @ScaledMetric(relativeTo: .body) private var optionIconSize: CGFloat = 15
-
     var body: some View {
         List(selection: self.$model.selectedIDs) {
             Section {
@@ -128,16 +132,11 @@ struct FilterTransferCandidateListView: View {
                 }
             } header: {
                 if self.model.regularCandidates(for: self.filterType).count > 0 {
-                    HStack {
+                    AdaptiveColumnHeader(leadingAccessory: {
                         self.sectionSelectAll(self.model.regularCandidates(for: self.filterType))
-
-                        Text(self.filterType == .denyLanguage ? "general_lang"~ : "filterList_text"~)
-
-                        Spacer()
-
-                        Text(self.filterType.supportsAdvancedOptions ? "filterList_options"~ : "filterList_folder"~)
-                            .padding(.trailing, 8)
-                    }
+                    }, primary: self.filterType == .denyLanguage ? "general_lang"~ : "filterList_text"~,
+                       secondary: self.filterType.supportsAdvancedOptions ? "filterList_options"~ : "filterList_folder"~,
+                       secondaryIsMuted: false)
                 }
             }
 
@@ -147,10 +146,9 @@ struct FilterTransferCandidateListView: View {
                         self.candidateRow(candidate)
                     }
                 } header: {
-                    HStack {
+                    AdaptiveColumnHeader(leadingAccessory: {
                         self.sectionSelectAll(self.model.regexCandidates(for: self.filterType))
-                        Text("addFilter_match_regex"~)
-                    }
+                    }, primary: "addFilter_match_regex"~, secondary: "", secondaryIsMuted: false)
                 }
             }
         }
@@ -174,29 +172,32 @@ struct FilterTransferCandidateListView: View {
 
     @ViewBuilder
     private func candidateRow(_ candidate: FilterTransferCandidate) -> some View {
-        HStack(alignment: .center) {
+        AdaptiveRow {
+            EmptyView()
+        } content: {
             Text(self.model.displayName(for: candidate))
                 .font(candidate.filterMatching == .regex ? .system(.body, design: .monospaced) : .body)
                 .foregroundColor(.primary)
+                .fixedSize(horizontal: false, vertical: true)
+        } trailing: {
+            HStack(spacing: 4) {
+                if candidate.type.supportsAdvancedOptions {
+                    FilterRowOptionChip(systemName: candidate.filterTarget.icon,
+                                        isActive: candidate.filterTarget != .all)
 
-            Spacer()
+                    if candidate.filterMatching != .regex {
+                        FilterRowOptionChip(systemName: candidate.filterMatching.icon,
+                                            isActive: candidate.filterMatching == .exact)
+                        FilterRowOptionChip(systemName: candidate.filterCase.icon,
+                                            isActive: candidate.filterCase == .caseSensitive)
+                    }
+                }
 
-            if candidate.type.supportsAdvancedOptions {
-                self.optionIcon(systemName: candidate.filterTarget.icon,
-                                isActive: candidate.filterTarget != .all)
-
-                if candidate.filterMatching != .regex {
-                    self.optionIcon(systemName: candidate.filterMatching.icon,
-                                    isActive: candidate.filterMatching == .exact)
-
-                    self.optionIcon(systemName: candidate.filterCase.icon,
-                                    isActive: candidate.filterCase == .caseSensitive)
+                if candidate.type.supportsFolders {
+                    FilterRowOptionChip(systemName: candidate.denyFolder.iconName, isActive: true)
                 }
             }
-
-            if candidate.type.supportsFolders {
-                self.optionIcon(systemName: candidate.denyFolder.iconName, isActive: true)
-            }
+            .accessibilityHidden(true)
         }
         .tag(candidate.id)
         .accessibilityElement(children: .combine)
@@ -216,21 +217,6 @@ struct FilterTransferCandidateListView: View {
             parts.append(String(format: "a11y_filterRow_folderLabel"~, candidate.denyFolder.name))
         }
         return parts.joined(separator: ", ")
-    }
-
-    private func optionIcon(systemName: String, isActive: Bool) -> some View {
-        Image(systemName: systemName)
-            .resizable()
-            .aspectRatio(contentMode: .fit)
-            .foregroundStyle(isActive ? AnyShapeStyle(.tint) : AnyShapeStyle(.secondary))
-            .frame(width: self.optionIconSize, height: self.optionIconSize)
-            .padding(7)
-            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
-            .overlay(
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .strokeBorder(Color.primary.opacity(0.12), lineWidth: 0.5)
-            )
-            .accessibilityHidden(true)
     }
 }
 

--- a/Simply Filter SMS/View Layer/Screens/HelpView.swift
+++ b/Simply Filter SMS/View Layer/Screens/HelpView.swift
@@ -20,7 +20,6 @@ struct HelpView: View {
     private var reduceMotion
 
     @ScaledMetric(relativeTo: .body) private var iconSize: CGFloat = 22
-    @ScaledMetric(relativeTo: .body) private var rowIconSize: CGFloat = 20
 
     @StateObject var model: ViewModel
 
@@ -36,12 +35,13 @@ struct HelpView: View {
                         model.onRequestScreen?(.enableExtension)
                         dismiss()
                     } label: {
-                        HStack {
+                        AdaptiveRow {
                             Image(systemName: "switch.2")
                                 .foregroundStyle(.tint)
-                                .frame(maxWidth: rowIconSize, maxHeight: .infinity, alignment: .center)
                                 .font(.body)
+                                .adaptiveIconColumn(width: 22)
                                 .accessibilityHidden(true)
+                        } content: {
                             VStack(alignment: .leading, spacing: 2) {
                                 Text("help_enableFiltering_title"~)
                                     .font(.body.weight(.semibold))
@@ -50,7 +50,6 @@ struct HelpView: View {
                                     .font(.caption)
                                     .foregroundColor(.secondary)
                             }
-                            .padding(.leading, 8)
                         }
                     }
                     .accessibilityElement(children: .combine)
@@ -60,12 +59,13 @@ struct HelpView: View {
                         model.onRequestScreen?(.enableReportingExtension)
                         dismiss()
                     } label: {
-                        HStack {
+                        AdaptiveRow {
                             Image(systemName: "wand.and.stars")
                                 .foregroundStyle(.tint)
-                                .frame(maxWidth: rowIconSize, maxHeight: .infinity, alignment: .center)
                                 .font(.body)
+                                .adaptiveIconColumn(width: 22)
                                 .accessibilityHidden(true)
+                        } content: {
                             VStack(alignment: .leading, spacing: 2) {
                                 Text("help_enableReporting_title"~)
                                     .font(.body.weight(.semibold))
@@ -74,7 +74,6 @@ struct HelpView: View {
                                     .font(.caption)
                                     .foregroundColor(.secondary)
                             }
-                            .padding(.leading, 8)
                         }
                     }
                     .accessibilityElement(children: .combine)

--- a/Simply Filter SMS/View Layer/Screens/LanguageListView.swift
+++ b/Simply Filter SMS/View Layer/Screens/LanguageListView.swift
@@ -54,7 +54,9 @@ struct LanguageListView: View, ViewWithPersistentStoreReload {
                             }
                             
                         case .automaticBlocking:
-                            Toggle(localizedName, isOn: $model.languages[index].state)
+                            AdaptiveToggle(isOn: $model.languages[index].state) {
+                                Text(localizedName)
+                            }
                         }
                     }
                 }
@@ -63,21 +65,20 @@ struct LanguageListView: View, ViewWithPersistentStoreReload {
                     self.model.languages.count == 0 {
                     
                     if !self.model.isLoading {
-                        HStack (spacing: 12) {
+                        AdaptiveRow {
                             Image(systemName: "wifi.exclamationmark")
                                 .font(.system(size: errorIconSize))
                                 .foregroundColor(.red)
                                 .accessibilityHidden(true)
-
+                                .adaptiveIconColumn()
+                        } content: {
                             if self.model.isOnline {
                                 Text(.init("autoFilter_error"~))
-                                    .padding(.vertical, 16)
-                            }
-                            else {
+                            } else {
                                 Text(.init("autoFilter_empty"~))
-                                    .padding(.vertical, 16)
                             }
                         }
+                        .padding(.vertical, 16)
                     }
                     else {
                         ProgressView()

--- a/Simply Filter SMS/View Layer/Screens/ReportMessageView.swift
+++ b/Simply Filter SMS/View Layer/Screens/ReportMessageView.swift
@@ -92,6 +92,7 @@ struct ReportMessageView: View {
                     } footer: {
                         Text("reportingExtension_footer"~)
                             .multilineTextAlignment(.center)
+                            .limitedDynamicTypeSize()
                     }
                 }
                 .onAppear {

--- a/Simply Filter SMS/View Layer/Screens/Screen.swift
+++ b/Simply Filter SMS/View Layer/Screens/Screen.swift
@@ -17,86 +17,89 @@ enum Screen: Int, Identifiable, Hashable {
          chooseAccentColor, filterExport
 
     @ViewBuilder func build() -> some View {
-        switch self {
-        case .appHome:
-            AppHomeView(model: AppHomeView.ViewModel())
+        Group {
+            switch self {
+            case .appHome:
+                AppHomeView(model: AppHomeView.ViewModel())
 
-        case .onboarding, .enableExtension:
-            EnableExtensionView(model: EnableExtensionView.ViewModel(
-                steps: Array(EnableExtensionStep.allCases),
-                isInteractiveDismissDisabled: true,
-                onDismiss: {
-                    var defaultsManager = AppManager.shared.defaultsManager
-                    defaultsManager.isAppFirstRun = false
-                },
-                onCTA: {
-                    var defaultsManager = AppManager.shared.defaultsManager
-                    defaultsManager.isAppFirstRun = false
-                    UIApplication.shared.openSettings()
-                }
-            ))
+            case .onboarding, .enableExtension:
+                EnableExtensionView(model: EnableExtensionView.ViewModel(
+                    steps: Array(EnableExtensionStep.allCases),
+                    isInteractiveDismissDisabled: true,
+                    onDismiss: {
+                        var defaultsManager = AppManager.shared.defaultsManager
+                        defaultsManager.isAppFirstRun = false
+                    },
+                    onCTA: {
+                        var defaultsManager = AppManager.shared.defaultsManager
+                        defaultsManager.isAppFirstRun = false
+                        UIApplication.shared.openSettings()
+                    }
+                ))
 
-        case .help:
-            HelpView(model: HelpView.ViewModel())
+            case .help:
+                HelpView(model: HelpView.ViewModel())
 
-        case .about:
-            AboutView(model: AboutView.ViewModel())
+            case .about:
+                AboutView(model: AboutView.ViewModel())
 
-        case .testFilters:
-            TestFiltersView(model: TestFiltersView.ViewModel())
+            case .testFilters:
+                TestFiltersView(model: TestFiltersView.ViewModel())
 
-        case .addLanguageFilter:
-            LanguageListView(model: LanguageListView.ViewModel(mode: .blockLanguage))
+            case .addLanguageFilter:
+                LanguageListView(model: LanguageListView.ViewModel(mode: .blockLanguage))
 
-        case .addAllowFilter:
-            AddFilterView(model: AddFilterView.ViewModel(filterType: .allow))
+            case .addAllowFilter:
+                AddFilterView(model: AddFilterView.ViewModel(filterType: .allow))
 
-        case .addDenyFilter:
-            AddFilterView(model: AddFilterView.ViewModel(filterType: .deny))
+            case .addDenyFilter:
+                AddFilterView(model: AddFilterView.ViewModel(filterType: .deny))
 
-        case .automaticBlocking:
-            LanguageListView(model: LanguageListView.ViewModel(mode: .automaticBlocking))
+            case .automaticBlocking:
+                LanguageListView(model: LanguageListView.ViewModel(mode: .automaticBlocking))
 
-        case .denyFilterList:
-            FilterListView(model: FilterListView.ViewModel(filterType: .deny))
+            case .denyFilterList:
+                FilterListView(model: FilterListView.ViewModel(filterType: .deny))
 
-        case .allowFilterList:
-            FilterListView(model: FilterListView.ViewModel(filterType: .allow))
+            case .allowFilterList:
+                FilterListView(model: FilterListView.ViewModel(filterType: .allow))
 
-        case .denyLanguageFilterList:
-            FilterListView(model: FilterListView.ViewModel(filterType: .denyLanguage))
+            case .denyLanguageFilterList:
+                FilterListView(model: FilterListView.ViewModel(filterType: .denyLanguage))
 
-        case .reportMessage:
-            ReportMessageView(model: ReportMessageView.ViewModel())
+            case .reportMessage:
+                ReportMessageView(model: ReportMessageView.ViewModel())
 
-        case .whatsNew:
-            WhatsNewView(model: WhatsNewView.ViewModel())
+            case .whatsNew:
+                WhatsNewView(model: WhatsNewView.ViewModel())
 
-        case .tipJar:
-            TipJarView(model: TipJarView.ViewModel())
+            case .tipJar:
+                TipJarView(model: TipJarView.ViewModel())
 
-        case .countryList:
-            CountryListView(model: CountryListView.ViewModel())
+            case .countryList:
+                CountryListView(model: CountryListView.ViewModel())
 
-        case .enableReportingExtension:
-            EnableExtensionView(model: EnableExtensionView.ViewModel(
-                steps: Array(EnableReportingExtensionStep.allCases),
-                title: "autoFilter_improveAIFiltering"~,
-                description: "enableReportingExtension_desc"~,
-                isInteractiveDismissDisabled: false,
-                onDismiss: {},
-                onCTA: UIApplication.shared.openSettings
-            ))
+            case .enableReportingExtension:
+                EnableExtensionView(model: EnableExtensionView.ViewModel(
+                    steps: Array(EnableReportingExtensionStep.allCases),
+                    title: "autoFilter_improveAIFiltering"~,
+                    description: "enableReportingExtension_desc"~,
+                    isInteractiveDismissDisabled: false,
+                    onDismiss: {},
+                    onCTA: UIApplication.shared.openSettings
+                ))
 
-        case .filterImport:
-            FilterTransferPreviewView(model: FilterTransferPreviewView.ViewModel())
+            case .filterImport:
+                FilterTransferPreviewView(model: FilterTransferPreviewView.ViewModel())
 
-        case .chooseAccentColor:
-            ChooseAccentColorView(model: ChooseAccentColorView.ViewModel())
+            case .chooseAccentColor:
+                ChooseAccentColorView(model: ChooseAccentColorView.ViewModel())
 
-        case .filterExport:
-            FilterTransferPreviewView(model: FilterTransferPreviewView.ViewModel())
+            case .filterExport:
+                FilterTransferPreviewView(model: FilterTransferPreviewView.ViewModel())
+            }
         }
+        .adaptiveLayoutEnvironment()
     }
 
     var tag: String {

--- a/Simply Filter SMS/View Layer/Screens/TipJarView.swift
+++ b/Simply Filter SMS/View Layer/Screens/TipJarView.swift
@@ -106,7 +106,7 @@ struct TipJarView: View {
                     .multilineTextAlignment(.center)
                     .padding(.vertical, 20)
             } else {
-                HStack(spacing: 10) {
+                AdaptiveStack(spacing: 10) {
                     ForEach(model.products, id: \.id) { product in
                         if let tier = TipTier(rawValue: product.id) {
                             TipCardView(tier: tier, displayPrice: product.displayPrice, isDisabled: model.isPurchasing, isPurchasing: model.isPurchasing(tier: tier), isCompact: isCompact) {
@@ -127,6 +127,7 @@ struct TipJarView: View {
             .foregroundColor(.secondary)
             .multilineTextAlignment(.center)
             .fixedSize(horizontal: false, vertical: true)
+            .limitedDynamicTypeSize()
             .frame(maxWidth: .infinity)
             .padding(.bottom, 16)
     }

--- a/Simply Filter SMS/View Layer/Screens/WhatsNewView.swift
+++ b/Simply Filter SMS/View Layer/Screens/WhatsNewView.swift
@@ -14,8 +14,6 @@ struct WhatsNewView: View {
     @Environment(\.dismiss)
     var dismiss
 
-    @ScaledMetric(relativeTo: .title2) private var entryIconSize: CGFloat = 44
-
     @ObservedObject var model: ViewModel
 
     var body: some View {
@@ -23,15 +21,15 @@ struct WhatsNewView: View {
             VStack(spacing: 0) {
                 List {
                     ForEach(model.entries, id: \.self) { entry in
-                        let row = HStack(alignment: .top, spacing: 16) {
+                        let row = AdaptiveRow(compactAlignment: .top, compactSpacing: 16) {
                             Image(systemName: entry.imageName)
                                 .font(.title2)
                                 .foregroundColor(entry.color)
-                                .frame(width: entryIconSize, height: entryIconSize)
+                                .frame(width: 44, height: 44)
                                 .background(entry.color.opacity(0.1))
                                 .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
                                 .accessibilityHidden(true)
-
+                        } content: {
                             VStack(alignment: .leading, spacing: 4) {
                                 Text(entry.title)
                                     .font(.body.bold())
@@ -47,6 +45,7 @@ struct WhatsNewView: View {
                                         .foregroundColor(.secondary)
                                 }
                             }
+                            .fixedSize(horizontal: false, vertical: true)
                         }
                         .listRowSeparator(.hidden)
 

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -268,8 +268,8 @@ postfix func ~ (lang: NLLanguage) -> String {
 ## Running Tests
 
 ```bash
-# Unit tests
-xcodebuild -project "Simply Filter SMS.xcodeproj" -scheme "Simply Filter SMS" \
+# Unit tests (use the Tests scheme — avoids unsigned Tests.xctest load failures)
+xcodebuild -project "Simply Filter SMS.xcodeproj" -scheme "Tests" \
   -destination 'platform=iOS Simulator,name=iPhone 17 Pro' test
 
 # App Store screenshots (via Fastlane — configured in fastlane/Fastfile)

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -270,7 +270,7 @@ postfix func ~ (lang: NLLanguage) -> String {
 ```bash
 # Unit tests
 xcodebuild -project "Simply Filter SMS.xcodeproj" -scheme "Simply Filter SMS" \
-  -destination 'platform=iOS Simulator,name=iPhone 16' test
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' test
 
 # App Store screenshots (via Fastlane — configured in fastlane/Fastfile)
 fastlane iphone_screenshots        # iPhone only


### PR DESCRIPTION
## Summary
- Add shared `DynamicTypeLayout` helpers (`AdaptiveRow`, `AdaptiveToggle`, `AdaptiveStack`, etc.) so rows stack only at XX Large+ accessibility sizes
- Keep default-size behavior intact with hybrid footer/notification overlays; use safe-area insets only for large text
- Bump version to 3.1.2

## Test plan
- [x] Smoke home at default text size: offline toast stays a compact centered pill; footer still overlays without shrinking the list
- [x] Enable Larger Accessibility Text and confirm home rows (smart filters, your filters), filter list, and import/export are readable without overlap
- [x] Confirm footer and notification push content instead of covering it at large text
- [x] Spot-check Add Filter, Help, About, Tip Jar, What’s New, Country list, Enable Extension
- [x] Run unit tests on iPhone 17 Pro


Made with [Cursor](https://cursor.com)