### PR TITLE
Give list action buttons room above the Home footer

### DIFF
--- a/Simply Filter SMS/View Layer/Screens/FilterListView.swift
+++ b/Simply Filter SMS/View Layer/Screens/FilterListView.swift
@@ -242,7 +242,7 @@ struct FilterListView: View, ViewWithPersistentStoreReload {
             .buttonStyle(AccessibleTextButtonStyle())
             .frame(maxWidth: .infinity, alignment: .center)
             .padding(.top, 1)
-            .padding(.bottom, 16)
+            .padding(.bottom, 48)
             .highPriorityGesture(TapGesture()
                 .onEnded({ _ in
                 self.model.showAddFilter()

--- a/Simply Filter SMS/View Layer/Screens/LanguageListView.swift
+++ b/Simply Filter SMS/View Layer/Screens/LanguageListView.swift
@@ -113,7 +113,7 @@ struct LanguageListView: View, ViewWithPersistentStoreReload {
                         .buttonStyle(AccessibleTextButtonStyle())
                         .frame(maxWidth: .infinity, alignment: .center)
                         .padding(.top, 20)
-                        .padding(.bottom, 40)
+                        .padding(.bottom, 48)
                     }
                 }
             } // Section


### PR DESCRIPTION
## Summary
- Increase bottom padding under Add Filter so the button clears the version footer when scrolling.
- Match the same clearance on the Improve AI Filtering button.

## Test plan
- [x] Open Blocked Texts with enough filters that the Add button is at the bottom; confirm it scrolls fully above the version footer
- [x] Open Allowed Texts and confirm the same
- [x] Open Automatic Filters → language list and confirm Improve AI Filtering clears the footer
- [x] Spot-check Large Text still looks fine


Made with [Cursor](https://cursor.com)