### PR TITLE
Fix saved-rule tester parity and harden Message Filter persistence

### DIFF
--- a/Message Filter Extension/Info.plist
+++ b/Message Filter Extension/Info.plist
@@ -4,13 +4,6 @@
 <dict>
 	<key>NSExtension</key>
 	<dict>
-		<key>NSExtensionAttributes</key>
-		<dict>
-			<key>ILMessageFilterExtensionNetworkURL</key>
-			<string>https://www.example-sms-filter-application.com/api</string>
-			<key>RequestOpenAccess</key>
-			<true/>
-		</dict>
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.identitylookup.message-filter</string>
 		<key>NSExtensionPrincipalClass</key>

--- a/Message Filter Extension/MessageFilterExtension.swift
+++ b/Message Filter Extension/MessageFilterExtension.swift
@@ -17,14 +17,12 @@ final class MessageFilterExtension: ILMessageFilterExtension {
 
     override init() {
         super.init()
+        extensionManager.setLogger(logger)
         logger.debug("Extension loaded")
     }
 
-    lazy var extensionManager: MessageEvaluationManagerProtocol = {
-        let messageEvaluationManager = MessageEvaluationManager()
-        messageEvaluationManager.setLogger(self.logger)
-        return messageEvaluationManager
-    }()
+    let extensionManager = MessageEvaluationManager()
+
 }
 
 @available(iOS 16.0, *)
@@ -40,18 +38,15 @@ extension MessageFilterExtension: ILMessageFilterQueryHandling {
     func handle(_ queryRequest: ILMessageFilterQueryRequest,
                 context: ILMessageFilterExtensionContext,
                 completion: @escaping (ILMessageFilterQueryResponse) -> Void) {
-        let offlineAction = self.offlineAction(for: queryRequest)
-        let response = ILMessageFilterQueryResponse()
-        response.action = offlineAction
-        completion(response)
-    }
-
-    private func offlineAction(for queryRequest: ILMessageFilterQueryRequest) -> ILMessageFilterAction {
-        let body = queryRequest.messageBody ?? ""
-        let sender = queryRequest.sender ?? ""
-        logger.debug("▶▶▶ Query received | sender: '\(sender, privacy: .public)' | body: '\(body, privacy: .public)'")
-        let result = self.extensionManager.evaluateMessage(body: body, sender: sender)
-        logger.debug("◀◀◀ Extension response: \(result.action.logName, privacy: .public) | reason: '\(result.reason ?? "none", privacy: .public)'")
-        return result.action
+        let queryID = UUID().uuidString
+        let started = Date()
+        let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "unknown"
+        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+        logger.info("Query received: id=\(queryID, privacy: .public) version=\(version, privacy: .public) build=\(build, privacy: .public)")
+        extensionManager.evaluateMessage(body: queryRequest.messageBody ?? "", sender: queryRequest.sender ?? "") { result in
+            let response = result.makeResponse()
+            self.logger.info("Query completed: id=\(queryID, privacy: .public) match=\(result.match.logKind, privacy: .public) status=\(result.status.rawValue, privacy: .public) action=\(result.action.logName, privacy: .public) elapsed=\(Date().timeIntervalSince(started), privacy: .public)")
+            completion(response)
+        }
     }
 }

--- a/Simply Filter SMS.xcodeproj/xcshareddata/xcschemes/Tests.xcscheme
+++ b/Simply Filter SMS.xcodeproj/xcshareddata/xcschemes/Tests.xcscheme
@@ -10,8 +10,12 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldUseLaunchSchemeArgsEnv = "NO"
       codeCoverageEnabled = "YES">
+      <CommandLineArguments>
+         <CommandLineArgument argument = "-com.apple.CoreData.ConcurrencyDebug" isEnabled = "YES"/>
+         <CommandLineArgument argument = "1" isEnabled = "YES"/>
+      </CommandLineArguments>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -47,7 +51,7 @@
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
-      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldUseLaunchSchemeArgsEnv = "NO"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">

--- a/Simply Filter SMS/Framework Layer/Managers/AutomaticFilterManager.swift
+++ b/Simply Filter SMS/Framework Layer/Managers/AutomaticFilterManager.swift
@@ -136,7 +136,7 @@ class AutomaticFilterManager: AutomaticFilterManagerProtocol {
         AppManager.logger.debug("setLanguageAutomaticState — '\(language.localizedName ?? language.rawValue, privacy: .public)' → \(value, privacy: .public)")
         let automaticFiltersLanguage = persistanceManager.ensuredAutomaticFiltersLanguageRecord(for: language)
         automaticFiltersLanguage.isActive = value
-        persistanceManager.commitContext()
+        guard persistanceManager.commitContext() else { return }
         NotificationCenter.default.post(name: .filtersStateChanged, object: nil)
     }
     
@@ -154,7 +154,7 @@ class AutomaticFilterManager: AutomaticFilterManagerProtocol {
         if automaticFiltersRule.ruleType == .shortSender && automaticFiltersRule.selectedChoice < 3 {
             automaticFiltersRule.selectedChoice = 6
         }
-        persistanceManager.commitContext()
+        guard persistanceManager.commitContext() else { return }
         NotificationCenter.default.post(name: .filtersStateChanged, object: nil)
     }
 
@@ -169,7 +169,7 @@ class AutomaticFilterManager: AutomaticFilterManagerProtocol {
               let automaticFiltersRule = persistanceManager.fetchAutomaticFiltersRuleRecord(for: rule) else { return }
         AppManager.logger.debug("setSelectedChoice — '\(rule.title, privacy: .public)' → \(choice, privacy: .public)")
         automaticFiltersRule.selectedChoice = Int64(choice)
-        persistanceManager.commitContext()
+        guard persistanceManager.commitContext() else { return }
         NotificationCenter.default.post(name: .filtersStateChanged, object: nil)
     }
 
@@ -251,7 +251,7 @@ class AutomaticFilterManager: AutomaticFilterManagerProtocol {
         AppManager.logger.debug("updateCacheIfNeeded — isCacheStale: \(isCacheStale, privacy: .public), force: \(force, privacy: .public)")
         if force || isCacheStale {
             AppManager.logger.debug("updateCacheIfNeeded — saving new filter cache")
-            persistanceManager.saveCache(with: newFilterList)
+            guard persistanceManager.saveCache(with: newFilterList) else { return }
         }
         if isCacheStale {
             AppManager.logger.debug("updateCacheIfNeeded — posting automaticFiltersUpdated notification")

--- a/Simply Filter SMS/Framework Layer/Managers/MessageEvaluationManager.swift
+++ b/Simply Filter SMS/Framework Layer/Managers/MessageEvaluationManager.swift
@@ -15,106 +15,121 @@ class MessageEvaluationManager: MessageEvaluationManagerProtocol {
 
     //MARK: - Initialization -
 
-    /// Extension/tests — owns a read-only App Group store (in-memory when `inMemory` is true).
-    init(inMemory: Bool = false) {
-        let container = AppPersistentCloudKitContainer(name: kAppWorkingDirectory, isReadOnly: !inMemory)
+    /// Production readers open a fresh read-only store for each query. A failed open
+    /// is retried on the next query, and no live app context participates.
+    init(inMemory: Bool = false, storeURL: URL? = nil) {
         if inMemory {
+            let container = AppPersistentCloudKitContainer(name: kAppWorkingDirectory)
             container.persistentStoreDescriptions.first!.url = URL(fileURLWithPath: "/dev/null")
+            container.loadPersistentStores { _, _ in }
+            contextSource = .owned(container)
+        } else {
+            contextSource = .saved(storeURL)
         }
-
-        var loadError: Error?
-        let loaded = DispatchSemaphore(value: 0)
-        container.loadPersistentStores { (_, error) in
-            loadError = error
-            loaded.signal()
-        }
-        if loaded.wait(timeout: .now() + kOwnedStoreLoadTimeout) == .success, loadError == nil {
-            container.viewContext.stalenessInterval = 0
-            container.viewContext.automaticallyMergesChangesFromParent = true
-        }
-        else {
-            // Logger may not be set yet (extension calls setLogger after init).
-            let logger = Logger(subsystem: "com.grizz.apps.dev.Simply-Filter-SMS", category: "evaluation")
-            if let loadError {
-                logger.error("Owned store load failed: \(loadError.localizedDescription, privacy: .public)")
-            }
-            else {
-                logger.error("Owned store load timed out after \(kOwnedStoreLoadTimeout, privacy: .public)s")
-            }
-        }
-
-        self.contextSource = .owned(container)
     }
 
-    /// App — always reads the live `PersistanceManager` context.
     init(persistanceManager: PersistanceManagerProtocol) {
-        self.contextSource = .persistance(persistanceManager)
+        contextSource = .persistance(persistanceManager)
     }
 
-    //MARK: - Public API (MessageEvaluationManagerProtocol) -
+    init(context: NSManagedObjectContext) {
+        contextSource = .query(context)
+    }
+
+    private let evaluationQueue = DispatchQueue(label: "com.simplyfiltersms.saved-evaluation")
+
+    func evaluateMessage(body: String, sender: String, completion: @escaping (MessageEvaluationResult) -> Void) {
+        evaluationQueue.async {
+            completion(self.evaluateMessage(body: body, sender: sender))
+        }
+    }
 
     func evaluateMessage(body: String, sender: String) -> MessageEvaluationResult {
-        if case .owned(let container) = self.contextSource,
-           container.persistentStoreCoordinator.persistentStores.isEmpty {
-            self.logger?.error("Owned store unavailable — skipping evaluation (allow)")
-            return MessageEvaluationResult(action: .allow, match: .storeUnavailable)
+        if case .saved(let overrideURL) = contextSource {
+            do {
+                let url = try overrideURL ?? AppPersistentCloudKitContainer.sharedStoreURL()
+                guard FileManager.default.fileExists(atPath: url.path) else {
+                    throw NSError(domain: "SavedRulesStore", code: 1)
+                }
+                let container = AppPersistentCloudKitContainer(name: kAppWorkingDirectory, isReadOnly: true)
+                container.persistentStoreDescriptions.first!.url = url
+                // Deliberately synchronous on the caller's worker queue. No invented
+                // timeout, semaphore race, or retained failed container.
+                container.persistentStoreDescriptions.first!.shouldAddStoreAsynchronously = false
+                var loadError: Error?
+                container.loadPersistentStores { _, error in loadError = error }
+                if let loadError { throw loadError }
+                guard !container.persistentStoreCoordinator.persistentStores.isEmpty else {
+                    throw NSError(domain: "SavedRulesStore", code: 2)
+                }
+                let context = container.newBackgroundContext()
+                defer {
+                    context.performAndWait { context.reset() }
+                    for store in container.persistentStoreCoordinator.persistentStores {
+                        try? container.persistentStoreCoordinator.remove(store)
+                    }
+                }
+                return context.performAndWait {
+                    do {
+                        try context.setQueryGenerationFrom(.current)
+                        let evaluator = MessageEvaluationManager(context: context)
+                        return try evaluator.evaluateRules(body: body, sender: sender)
+                    } catch {
+                        return self.failure(error, status: .readFailed)
+                    }
+                }
+            } catch {
+                return failure(error, status: .storeUnavailable)
+            }
         }
+        return context.performAndWait {
+            do { return try self.evaluateRules(body: body, sender: sender) }
+            catch { return self.failure(error, status: .readFailed) }
+        }
+    }
 
-        logger?.debug("━━━━ Evaluating message | sender: '\(sender, privacy: .public)' | body: '\(body, privacy: .public)' ━━━━")
+    private func failure(_ error: Error, status: MessageEvaluationStatus) -> MessageEvaluationResult {
+        let error = error as NSError
+        logger?.error("Rules evaluation failed: status=\(status.rawValue, privacy: .public) domain=\(error.domain, privacy: .public) code=\(error.code, privacy: .public)")
+        return MessageEvaluationResult(action: .allow, match: .storeUnavailable, status: status)
+    }
+
+    private func evaluateRules(body: String, sender: String) throws -> MessageEvaluationResult {
         var result = MessageEvaluationResult(action: .none)
-        defer {
-            logger?.debug("━━━━ Final decision: action=\(result.action.logName, privacy: .public), reason='\(result.reason ?? "", privacy: .public)' ━━━━")
-        }
         // Priority #1 - Allow Filters
-        result = self.runUserFilters(type: .allow, body: body, sender: sender)
+        result = try self.runUserFilters(type: .allow, body: body, sender: sender)
         guard !result.action.isFiltered else {
-            logger?.debug("Priority #1 (Allow Filters) → DECISION: \(result.action.logName, privacy: .public)")
             return result
         }
-        logger?.debug("Priority #1 (Allow Filters) → no match, continuing")
         // Priority #2 - allUnknown (absolute gate, overrides everything)
-        result = self.runAllUnknownRule()
+        result = try self.runAllUnknownRule()
         guard !result.action.isFiltered else {
-            logger?.debug("Priority #2 (allUnknown) → DECISION: \(result.action.logName, privacy: .public)")
             return result
         }
-        logger?.debug("Priority #2 (allUnknown) → not active, continuing")
         // Priority #3 - Automatic Filters (allow)
-        result = self.runAutomaticFiltersAllow(body: body, sender: sender)
+        result = try self.runAutomaticFiltersAllow(body: body, sender: sender)
         guard !result.action.isFiltered else {
-            logger?.debug("Priority #3 (Automatic Filters Allow) → DECISION: \(result.action.logName, privacy: .public)")
             return result
         }
-        logger?.debug("Priority #3 (Automatic Filters Allow) → no match, continuing")
         // Priority #4 - Filter Rules
-        result = self.runFilterRules(body: body, sender: sender)
+        result = try self.runFilterRules(body: body, sender: sender)
         guard !result.action.isFiltered else {
-            logger?.debug("Priority #4 (Filter Rules) → DECISION: \(result.action.logName, privacy: .public)")
             return result
         }
-        logger?.debug("Priority #4 (Filter Rules) → no match, continuing")
         // Priority #5 - Deny Filters
-        result = self.runUserFilters(type: .deny, body: body, sender: sender)
+        result = try self.runUserFilters(type: .deny, body: body, sender: sender)
         guard !result.action.isFiltered else {
-            logger?.debug("Priority #5 (Deny Filters) → DECISION: \(result.action.logName, privacy: .public)")
             return result
         }
-        logger?.debug("Priority #5 (Deny Filters) → no match, continuing")
         // Priority #6 - Deny Language Filters
-        result = self.runUserFilters(type: .denyLanguage, body: body, sender: sender)
+        result = try self.runUserFilters(type: .denyLanguage, body: body, sender: sender)
         guard !result.action.isFiltered else {
-            logger?.debug("Priority #6 (Deny Language Filters) → DECISION: \(result.action.logName, privacy: .public)")
             return result
         }
-        logger?.debug("Priority #6 (Deny Language Filters) → no match, continuing")
         // Priority #7 - Automatic Filters (deny)
-        result = self.runAutomaticFiltersDeny(body: body, sender: sender)
+        result = try self.runAutomaticFiltersDeny(body: body, sender: sender)
         if !result.action.isFiltered {
             result = MessageEvaluationResult(action: .allow, match: .noMatch)
-            logger?.debug("Priority #7 (Automatic Filters Deny) → no match → fallthrough ALLOW")
-        }
-        else {
-            logger?.debug("Priority #7 (Automatic Filters Deny) → DECISION: \(result.action.logName, privacy: .public)")
         }
         return result
     }
@@ -129,6 +144,10 @@ class MessageEvaluationManager: MessageEvaluationManagerProtocol {
             return persistanceManager.context
         case .owned(let container):
             return container.viewContext
+        case .query(let context):
+            return context
+        case .saved:
+            preconditionFailure("Saved readers do not expose a managed object context")
         }
     }
 
@@ -137,91 +156,79 @@ class MessageEvaluationManager: MessageEvaluationManagerProtocol {
     private enum ContextSource {
         case persistance(PersistanceManagerProtocol)
         case owned(NSPersistentCloudKitContainer)
+        case saved(URL?)
+        case query(NSManagedObjectContext)
     }
 
     private var logger: Logger?
     private let contextSource: ContextSource
 
-    private func runAllUnknownRule() -> MessageEvaluationResult {
+    private func runAllUnknownRule() throws -> MessageEvaluationResult {
         let ruleRequest: NSFetchRequest<AutomaticFiltersRule> = AutomaticFiltersRule.fetchRequest()
         ruleRequest.predicate = NSPredicate(format: "ruleId == %ld AND isActive == %@",
                                             RuleType.allUnknown.rawValue,
                                             NSNumber(value: true))
-        guard (try? self.context.fetch(ruleRequest))?.isEmpty == false else {
+        guard try !self.context.fetch(ruleRequest).isEmpty else {
             return MessageEvaluationResult(action: .none)
         }
-        logger?.debug("[allUnknown] rule is active")
         return MessageEvaluationResult(action: .junk, match: .smartFilter("testFilters_resultReason_unknownSender"~))
     }
 
-    private func runUserFilters(type: FilterType, body: String, sender: String) -> MessageEvaluationResult {
+    private func runUserFilters(type: FilterType, body: String, sender: String) throws -> MessageEvaluationResult {
         var result = MessageEvaluationResult(action: .none)
         let fetchRequest = NSFetchRequest<NSManagedObject>(entityName: "Filter")
         fetchRequest.predicate = NSPredicate(format: "type == %ld", type.rawValue)
-        guard let filters = try? self.context.fetch(fetchRequest) else {
-            self.logger?.error("ERROR! While loading filters on MessageEvaluationManager.runUserFilters")
-            return result
-        }
-        logger?.debug("[\(type.logDescription, privacy: .public)] Loaded \(filters.count, privacy: .public) filter(s)")
+        let filters = try self.context.fetch(fetchRequest)
         switch type {
         case .allow:
             for filter in filters {
                 guard let filter = filter as? Filter else { continue }
                 let matched = self.isMatching(filter: filter, body: body, sender: sender)
-                logger?.debug("  Checking allow filter '\(filter.text ?? "?", privacy: .public)' [target: \(filter.filterTarget.logDescription, privacy: .public), matching: \(filter.filterMatching.logDescription, privacy: .public), case: \(filter.filterCase.logDescription, privacy: .public)] → \(matched ? "MATCH" : "no match", privacy: .public)")
                 guard matched else { continue }
                 result = MessageEvaluationResult(action: .allow, match: .userFilter(filter.text ?? ""))
-                logger?.debug("  → Returning ALLOW")
                 break
             }
         case .deny:
             for filter in filters {
                 guard let filter = filter as? Filter else { continue }
                 let matched = self.isMatching(filter: filter, body: body, sender: sender)
-                logger?.debug("  Checking deny filter '\(filter.text ?? "?", privacy: .public)' [target: \(filter.filterTarget.logDescription, privacy: .public), matching: \(filter.filterMatching.logDescription, privacy: .public), case: \(filter.filterCase.logDescription, privacy: .public), folder: \(filter.denyFolderType.logDescription, privacy: .public)] → \(matched ? "MATCH" : "no match", privacy: .public)")
                 guard matched else { continue }
                 result = MessageEvaluationResult(action: filter.denyFolderType.action, match: .userFilter(filter.text ?? ""))
-                logger?.debug("  → Returning \(result.action.logName, privacy: .public) (folder: \(filter.denyFolderType.logDescription, privacy: .public))")
                 break
             }
         case .denyLanguage:
             let detectedLanguage = NLLanguage.dominantLanguage(for: body)
-            logger?.debug("  Detected message language: '\(detectedLanguage?.rawValue ?? "undetermined", privacy: .public)'")
             for filter in filters {
                 guard let filter = filter as? Filter else { continue }
                 let language = NLLanguage(filterText: filter.text ?? "")
                 let matched = language != .undetermined && detectedLanguage == language
-                logger?.debug("  Checking language filter '\(language.localizedName ?? language.rawValue, privacy: .public)' → \(matched ? "MATCH" : "no match", privacy: .public)")
                 guard matched else { continue }
                 result = MessageEvaluationResult(action: filter.denyFolderType.action, match: .userFilter(language.localizedName ?? language.rawValue))
-                logger?.debug("  → Returning \(result.action.logName, privacy: .public) for language '\(language.localizedName ?? language.rawValue, privacy: .public)'")
                 break
             }
         }
         return result
     }
 
-    private func loadAutomaticFilterCache() -> ([AutomaticFiltersLanguage], AutomaticFilterListsResponse)? {
+    private func loadAutomaticFilterCache() throws -> ([AutomaticFiltersLanguage], AutomaticFilterListsResponse)? {
         let languageRequest: NSFetchRequest<AutomaticFiltersLanguage> = AutomaticFiltersLanguage.fetchRequest()
         let cacheRequest: NSFetchRequest<AutomaticFiltersCache> = AutomaticFiltersCache.fetchRequest()
-        guard let languageRecords = try? self.context.fetch(languageRequest),
-              let cacheRow = try? self.context.fetch(cacheRequest).first,
-              let filtersData = cacheRow.filtersData,
+        let languageRecords = try self.context.fetch(languageRequest)
+        guard let cacheRow = try self.context.fetch(cacheRequest).first else { return nil }
+        guard let filtersData = cacheRow.filtersData,
               let filterList = AutomaticFilterListsResponse(base64String: filtersData) else {
-            return nil
+            throw NSError(domain: "SavedRulesCache", code: 1)
         }
         return (languageRecords, filterList)
     }
 
-    private func runAutomaticFiltersAllow(body: String, sender: String) -> MessageEvaluationResult {
+    private func runAutomaticFiltersAllow(body: String, sender: String) throws -> MessageEvaluationResult {
         var result = MessageEvaluationResult(action: .none)
         let lowercasedBody = body.lowercased()
         let lowercasedSender = sender.lowercased()
-        guard let (languageRecords, filterList) = self.loadAutomaticFilterCache() else {
-            logger?.debug("[Automatic Filters Allow] no cache, skipping")
+        guard let (languageRecords, filterList) = try self.loadAutomaticFilterCache() else {
             return result
         }
-        logger?.debug("[Automatic Filters Allow] \(languageRecords.count, privacy: .public) language record(s)")
         for record in languageRecords {
             guard result.action == .none,
                   record.isActive,
@@ -231,7 +238,6 @@ class MessageEvaluationManager: MessageEvaluationManagerProtocol {
             for allowedSender in languageResponse.allowSenders {
                 if lowercasedSender == allowedSender.lowercased() {
                     result = MessageEvaluationResult(action: .allow, match: .automaticFilter(lang.localizedName ?? langRawValue))
-                    logger?.debug("  → ALLOW: matched allow sender '\(allowedSender, privacy: .public)' [\(lang.localizedName ?? langRawValue, privacy: .public)]")
                     break
                 }
             }
@@ -239,7 +245,6 @@ class MessageEvaluationManager: MessageEvaluationManagerProtocol {
             for allowedBody in languageResponse.allowBody {
                 if lowercasedBody.contains(allowedBody.lowercased()) {
                     result = MessageEvaluationResult(action: .allow, match: .automaticFilter(lang.localizedName ?? langRawValue))
-                    logger?.debug("  → ALLOW: matched allow body phrase '\(allowedBody, privacy: .public)' [\(lang.localizedName ?? langRawValue, privacy: .public)]")
                     break
                 }
             }
@@ -247,26 +252,22 @@ class MessageEvaluationManager: MessageEvaluationManagerProtocol {
         return result
     }
 
-    private func runAutomaticFiltersDeny(body: String, sender: String) -> MessageEvaluationResult {
+    private func runAutomaticFiltersDeny(body: String, sender: String) throws -> MessageEvaluationResult {
         var result = MessageEvaluationResult(action: .none)
         let lowercasedBody = body.lowercased()
         let lowercasedSender = sender.lowercased()
-        guard let (languageRecords, filterList) = self.loadAutomaticFilterCache() else {
-            logger?.debug("[Automatic Filters Deny] no cache, skipping")
+        guard let (languageRecords, filterList) = try self.loadAutomaticFilterCache() else {
             return result
         }
-        logger?.debug("[Automatic Filters Deny] \(languageRecords.count, privacy: .public) language record(s)")
         for record in languageRecords {
             guard result.action == .none,
                   record.isActive,
                   let langRawValue = record.lang,
                   let languageResponse = filterList.filterLists[langRawValue] else { continue }
             let lang = NLLanguage(rawValue: langRawValue)
-            logger?.debug("  Checking language '\(lang.localizedName ?? langRawValue, privacy: .public)' — denySenders: \(languageResponse.denySender.count, privacy: .public), denyBody: \(languageResponse.denyBody.count, privacy: .public)")
             for deniedSender in languageResponse.denySender {
                 if lowercasedSender == deniedSender.lowercased() {
                     result = MessageEvaluationResult(action: .junk, match: .automaticFilter(lang.localizedName ?? langRawValue))
-                    logger?.debug("  → JUNK: matched deny sender '\(deniedSender, privacy: .public)' [\(lang.localizedName ?? langRawValue, privacy: .public)]")
                     break
                 }
             }
@@ -274,7 +275,6 @@ class MessageEvaluationManager: MessageEvaluationManagerProtocol {
             for deniedBody in languageResponse.denyBody {
                 if lowercasedBody.contains(deniedBody.lowercased()) {
                     result = MessageEvaluationResult(action: .junk, match: .automaticFilter(lang.localizedName ?? langRawValue))
-                    logger?.debug("  → JUNK: matched deny body phrase '\(deniedBody, privacy: .public)' [\(lang.localizedName ?? langRawValue, privacy: .public)]")
                     break
                 }
             }
@@ -282,79 +282,48 @@ class MessageEvaluationManager: MessageEvaluationManagerProtocol {
         return result
     }
 
-    private func runFilterRules(body: String, sender: String) -> MessageEvaluationResult {
+    private func runFilterRules(body: String, sender: String) throws -> MessageEvaluationResult {
         var result = MessageEvaluationResult(action: .none)
         let ruleRequest: NSFetchRequest<AutomaticFiltersRule> = AutomaticFiltersRule.fetchRequest()
         ruleRequest.predicate = NSPredicate(format: "isActive == %@", NSNumber(value: true))
-        guard let activeRules = try? self.context.fetch(ruleRequest) else {
-            self.logger?.error("ERROR! While loading rules on MessageEvaluationManager.runFilterRules")
-            return result
-        }
-        logger?.debug("[Filter Rules] \(activeRules.count, privacy: .public) active rule(s)")
+        let activeRules = try self.context.fetch(ruleRequest)
         for activeRule in activeRules {
             guard let ruleType = activeRule.ruleType else { continue }
-            logger?.debug("  Checking rule: \(ruleType.logDescription, privacy: .public)")
             switch ruleType {
             case .allUnknown:
                 break
             case .links:
                 if body.containsLink {
                     result = MessageEvaluationResult(action: .junk, match: .smartFilter(ruleType.shortTitle))
-                    logger?.debug("  → JUNK: links — body contains a link")
-                }
-                else {
-                    logger?.debug("  → no link detected in body")
                 }
             case .numbersOnly:
                 if sender.rangeOfCharacter(from: .letters) != nil {
                     result = MessageEvaluationResult(action: .junk, match: .smartFilter(ruleType.shortTitle))
-                    logger?.debug("  → JUNK: numbersOnly — sender '\(sender, privacy: .public)' triggered rule")
-                }
-                else {
-                    logger?.debug("  → sender '\(sender, privacy: .public)' did not trigger numbersOnly rule")
                 }
             case .shortSender:
                 if sender.count <= Int(activeRule.selectedChoice) {
                     result = MessageEvaluationResult(action: .junk, match: .smartFilter(ruleType.shortTitle))
-                    logger?.debug("  → JUNK: shortSender — sender length \(sender.count, privacy: .public) ≤ threshold \(Int(activeRule.selectedChoice), privacy: .public)")
-                }
-                else {
-                    logger?.debug("  → sender length \(sender.count, privacy: .public) > threshold \(Int(activeRule.selectedChoice), privacy: .public), not short")
                 }
             case .email:
                 if sender.containsEmail {
                     result = MessageEvaluationResult(action: .junk, match: .smartFilter(ruleType.shortTitle))
-                    logger?.debug("  → JUNK: email — sender '\(sender, privacy: .public)' looks like an email address")
-                }
-                else {
-                    logger?.debug("  → sender '\(sender, privacy: .public)' is not an email address")
                 }
             case .emojis:
                 if body.containsEmoji {
                     result = MessageEvaluationResult(action: .junk, match: .smartFilter(ruleType.shortTitle))
-                    logger?.debug("  → JUNK: emojis — body contains emoji(s)")
-                }
-                else {
-                    logger?.debug("  → body contains no emojis")
                 }
             case .countryAllowlist:
                 guard let json = activeRule.selectedCountries,
                       let data = json.data(using: .utf8),
                       let allowedCodes = try? JSONDecoder().decode([String].self, from: data),
                       !allowedCodes.isEmpty else {
-                    logger?.debug("  → countryAllowlist: no allowed codes configured, skipping")
                     break
                 }
                 guard let entry = CallingCodes.callingCode(for: sender) else {
-                    logger?.debug("  → countryAllowlist: could not determine country for sender '\(sender, privacy: .public)', skipping")
                     break
                 }
                 if !allowedCodes.contains(entry.callingCode) {
                     result = MessageEvaluationResult(action: .junk, match: .smartFilter(ruleType.shortTitle))
-                    logger?.debug("  → JUNK: countryAllowlist — sender country '\(entry.callingCode, privacy: .public)' not in allowed list \(allowedCodes, privacy: .public)")
-                }
-                else {
-                    logger?.debug("  → countryAllowlist: sender country '\(entry.callingCode, privacy: .public)' is allowed")
                 }
             }
             if result.action.isFiltered { break }

--- a/Simply Filter SMS/Framework Layer/Managers/PersistanceManager.swift
+++ b/Simply Filter SMS/Framework Layer/Managers/PersistanceManager.swift
@@ -9,19 +9,38 @@ import Foundation
 import CoreData
 import NaturalLanguage
 import UIKit
+import Combine
+
+final class RulesSaveState: ObservableObject {
+    static let shared = RulesSaveState()
+    @Published var failed = false
+    var titleKey = "rules_saveFailedTitle"
+    var messageKey = "rules_saveFailedMessage"
+
+    func reportFailure(loading: Bool = false) {
+        DispatchQueue.main.async {
+            self.titleKey = loading ? "rules_loadFailedTitle" : "rules_saveFailedTitle"
+            self.messageKey = loading ? "rules_loadFailedMessage" : "rules_saveFailedMessage"
+            self.failed = true
+        }
+    }
+}
+
 
 class PersistanceManager: PersistanceManagerProtocol {
 
     
     //MARK: - Initialization -
-    required init(inMemory: Bool = false) {
+    required init(inMemory: Bool = false, storeURL: URL? = nil) {
         let container = AppPersistentCloudKitContainer(name: kAppWorkingDirectory)
         self.container = container
+        if let storeURL { container.persistentStoreDescriptions.first!.url = storeURL }
 
         if inMemory {
             container.persistentStoreDescriptions.first!.url = URL(fileURLWithPath: "/dev/null")
         }
         else if let storeURL = self.container.persistentStoreDescriptions.first?.url?.deletingLastPathComponent(),
+                !storeURL.path.hasPrefix("/unavailable-app-group"),
                 !FileManager.default.directoryExistsAtPath(storeURL.path) {
 
             try? FileManager.default.createDirectory(at: storeURL,
@@ -34,7 +53,9 @@ class PersistanceManager: PersistanceManagerProtocol {
 
         container.loadPersistentStores(completionHandler: { (storeDescription, error) in
             if let error = error as NSError? {
-                AppManager.logger.error("ERROR! While initializing PersistanceManager: \(error), \(error.userInfo)")
+                AppManager.logger.error("Store load failed: domain=\(error.domain, privacy: .public) code=\(error.code, privacy: .public)")
+                RulesSaveState.shared.reportFailure(loading: true)
+                return
             }
 
             container.viewContext.mergePolicy = NSMergePolicy(merge: .overwriteMergePolicyType)
@@ -60,26 +81,33 @@ class PersistanceManager: PersistanceManagerProtocol {
         return fingerprint
     }
     
-    func commitContext() {
-        guard self.context.hasChanges else {
-            AppManager.logger.debug("commitContext — skipped, no changes")
-            return
-        }
-        
-        do {
-            try self.context.save()
-            AppManager.logger.debug("commitContext — save succeeded")
-        } catch {
-            let nsError = error as NSError
-            AppManager.logger.error("ERROR! While commiting context: \(nsError), \(nsError.userInfo)")
+    var saveContext: (NSManagedObjectContext) throws -> Void = { try $0.save() }
+
+    /// Failed edits are rolled back so the UI cannot present them as active rules.
+    @discardableResult
+    func commitContext() -> Bool {
+        context.performAndWait {
+            do {
+                guard !container.persistentStoreCoordinator.persistentStores.isEmpty else {
+                    throw NSError(domain: "RulesStoreUnavailable", code: 1)
+                }
+                if context.hasChanges { try saveContext(context) }
+                return true
+            } catch {
+                let error = error as NSError
+                AppManager.logger.error("Rules save failed: domain=\(error.domain, privacy: .public) code=\(error.code, privacy: .public)")
+                context.rollback()
+                RulesSaveState.shared.reportFailure()
+                return false
+            }
         }
     }
-    
+
     func reloadContainer() {
         guard let storeURL = self.container.persistentStoreDescriptions.first?.url, storeURL != URL(fileURLWithPath: "/dev/null") else { return }
         AppManager.logger.debug("reloadContainer — reloading persistent store")
         if let loadedStore = self.container.persistentStoreCoordinator.persistentStore(for: storeURL) {
-            self.commitContext()
+            guard self.commitContext() else { return }
             self.container.viewContext.reset()
             try? self.container.persistentStoreCoordinator.remove(loadedStore)
         }
@@ -92,7 +120,9 @@ class PersistanceManager: PersistanceManagerProtocol {
 
         container.loadPersistentStores(completionHandler: { (storeDescription, error) in
             if let error = error as NSError? {
-                AppManager.logger.error("ERROR! While initializing PersistanceManager: \(error), \(error.userInfo)")
+                AppManager.logger.error("Store load failed: domain=\(error.domain, privacy: .public) code=\(error.code, privacy: .public)")
+                RulesSaveState.shared.reportFailure(loading: true)
+                return
             }
 
             container.viewContext.mergePolicy = NSMergePolicy(merge: .overwriteMergePolicyType)
@@ -253,7 +283,6 @@ class PersistanceManager: PersistanceManagerProtocol {
                                       filterTarget: filterTarget,
                                       filterMatching: filterMatching,
                                       filterCase: filterCase) else {
-            AppManager.logger.debug("addFilter — skipped duplicate: '\(text, privacy: .public)'")
             return nil
         }
 
@@ -265,31 +294,27 @@ class PersistanceManager: PersistanceManagerProtocol {
         newFilter.filterTarget = filterTarget
         newFilter.filterCase = filterCase
         newFilter.text = text
-        AppManager.logger.debug("addFilter — '\(text, privacy: .public)' | type: \(type.logDescription, privacy: .public) | folder: \(denyFolder.logDescription, privacy: .public) | target: \(filterTarget.logDescription, privacy: .public) | matching: \(filterMatching.logDescription, privacy: .public) | case: \(filterCase.logDescription, privacy: .public)")
-        self.commitContext()
+        guard self.commitContext() else { return nil }
         NotificationCenter.default.post(name: .filtersStateChanged, object: nil)
         return newFilter
     }
 
     func deleteFilters(withOffsets offsets: IndexSet, in filters: [Filter]) {
         let toDelete = offsets.map({ filters[$0] })
-        AppManager.logger.debug("deleteFilters — \(toDelete.count, privacy: .public) filter(s): \(toDelete.compactMap({ $0.text }).joined(separator: ", "), privacy: .public)")
         toDelete.forEach({ self.context.delete($0) })
-        self.commitContext()
+        guard self.commitContext() else { return }
         NotificationCenter.default.post(name: .filtersStateChanged, object: nil)
     }
 
     func deleteFilters(_ filters: Set<Filter>) {
-        AppManager.logger.debug("deleteFilters — \(filters.count, privacy: .public) filter(s): \(filters.compactMap({ $0.text }).joined(separator: ", "), privacy: .public)")
         filters.forEach({ self.context.delete($0) })
-        self.commitContext()
+        guard self.commitContext() else { return }
         NotificationCenter.default.post(name: .filtersStateChanged, object: nil)
     }
 
     func updateFilter(_ filter: Filter, denyFolder: DenyFolderType) {
-        AppManager.logger.debug("updateFilter — '\(filter.text ?? "", privacy: .public)' denyFolder → \(denyFolder.logDescription, privacy: .public)")
         filter.denyFolderType = denyFolder
-        self.commitContext()
+        guard self.commitContext() else { return }
         NotificationCenter.default.post(name: .filtersStateChanged, object: nil)
     }
 
@@ -298,12 +323,10 @@ class PersistanceManager: PersistanceManagerProtocol {
                                       filterTarget: filter.filterTarget,
                                       filterMatching: filterMatching,
                                       filterCase: filter.filterCase) else {
-            AppManager.logger.debug("updateFilter — skipped duplicate: '\(filter.text ?? "", privacy: .public)' filterMatching → \(filterMatching.logDescription, privacy: .public)")
             return
         }
-        AppManager.logger.debug("updateFilter — '\(filter.text ?? "", privacy: .public)' filterMatching → \(filterMatching.logDescription, privacy: .public)")
         filter.filterMatching = filterMatching
-        self.commitContext()
+        guard self.commitContext() else { return }
         NotificationCenter.default.post(name: .filtersStateChanged, object: nil)
     }
 
@@ -312,12 +335,10 @@ class PersistanceManager: PersistanceManagerProtocol {
                                       filterTarget: filter.filterTarget,
                                       filterMatching: filter.filterMatching,
                                       filterCase: filterCase) else {
-            AppManager.logger.debug("updateFilter — skipped duplicate: '\(filter.text ?? "", privacy: .public)' filterCase → \(filterCase.logDescription, privacy: .public)")
             return
         }
-        AppManager.logger.debug("updateFilter — '\(filter.text ?? "", privacy: .public)' filterCase → \(filterCase.logDescription, privacy: .public)")
         filter.filterCase = filterCase
-        self.commitContext()
+        guard self.commitContext() else { return }
         NotificationCenter.default.post(name: .filtersStateChanged, object: nil)
     }
 
@@ -326,12 +347,10 @@ class PersistanceManager: PersistanceManagerProtocol {
                                       filterTarget: filterTarget,
                                       filterMatching: filter.filterMatching,
                                       filterCase: filter.filterCase) else {
-            AppManager.logger.debug("updateFilter — skipped duplicate: '\(filter.text ?? "", privacy: .public)' filterTarget → \(filterTarget.logDescription, privacy: .public)")
             return
         }
-        AppManager.logger.debug("updateFilter — '\(filter.text ?? "", privacy: .public)' filterTarget → \(filterTarget.logDescription, privacy: .public)")
         filter.filterTarget = filterTarget
-        self.commitContext()
+        guard self.commitContext() else { return }
         NotificationCenter.default.post(name: .filtersStateChanged, object: nil)
     }
 
@@ -340,13 +359,10 @@ class PersistanceManager: PersistanceManagerProtocol {
                                       filterTarget: filter.filterTarget,
                                       filterMatching: filter.filterMatching,
                                       filterCase: filter.filterCase) else {
-            AppManager.logger.debug("updateFilter — skipped duplicate: '\(filter.text ?? "", privacy: .public)' text → '\(filterText, privacy: .public)'")
             return
         }
-        AppManager.logger.debug("updateFilter — '\(filter.text ?? "", privacy: .public)' text → '\(filterText, privacy: .public)', hasChangesBefore: \(self.context.hasChanges, privacy: .public)")
         filter.text = filterText
-        AppManager.logger.debug("updateFilter — after set text, hasChanges: \(self.context.hasChanges, privacy: .public)")
-        self.commitContext()
+        guard self.commitContext() else { return }
         NotificationCenter.default.post(name: .filtersStateChanged, object: nil)
     }
     
@@ -364,11 +380,12 @@ class PersistanceManager: PersistanceManagerProtocol {
            let json = String(data: data, encoding: .utf8) {
             record.selectedCountries = json
         }
-        self.commitContext()
+        guard self.commitContext() else { return }
         NotificationCenter.default.post(name: .filtersStateChanged, object: nil)
     }
 
-    func saveCache(with filterList: AutomaticFilterListsResponse) {
+    @discardableResult
+    func saveCache(with filterList: AutomaticFilterListsResponse) -> Bool {
         AppManager.logger.debug("saveCache — saving new automatic filters cache")
         self.deleteExistingCaches()
         let newCache = AutomaticFiltersCache(context: self.context)
@@ -376,7 +393,7 @@ class PersistanceManager: PersistanceManagerProtocol {
         newCache.hashed = filterList.hashed
         newCache.filtersData = filterList.encoded
         newCache.age = Date()
-        self.commitContext()
+        return self.commitContext()
     }
 
     func isCacheStale(comparedTo newFilterList: AutomaticFilterListsResponse) -> Bool {

--- a/Simply Filter SMS/Framework Layer/Managers/Protocols/MessageEvaluationManagerProtocol.swift
+++ b/Simply Filter SMS/Framework Layer/Managers/Protocols/MessageEvaluationManagerProtocol.swift
@@ -18,6 +18,17 @@ enum MessageEvaluationMatch: Equatable {
     case smartFilter(String)
     case automaticFilter(String)
 
+    var logKind: String {
+        switch self {
+        case .none: return "none"
+        case .noMatch: return "noMatch"
+        case .storeUnavailable: return "unavailable"
+        case .userFilter: return "userFilter"
+        case .smartFilter: return "smartFilter"
+        case .automaticFilter: return "automaticFilter"
+        }
+    }
+
     var label: String? {
         switch self {
         case .none, .storeUnavailable:
@@ -58,9 +69,21 @@ enum MessageEvaluationMatch: Equatable {
     }
 }
 
+enum MessageEvaluationStatus: String, Equatable {
+    case success, storeUnavailable, readFailed
+}
+
 struct MessageEvaluationResult: Equatable {
     var action: ILMessageFilterAction
     var match: MessageEvaluationMatch = .none
+
+    var status: MessageEvaluationStatus = .success
+
+    func makeResponse() -> ILMessageFilterQueryResponse {
+        let response = ILMessageFilterQueryResponse()
+        response.action = action
+        return response
+    }
 
     var reason: String? { match.caption }
 }

--- a/Simply Filter SMS/Framework Layer/Managers/Protocols/PersistanceManagerProtocol.swift
+++ b/Simply Filter SMS/Framework Layer/Managers/Protocols/PersistanceManagerProtocol.swift
@@ -15,7 +15,8 @@ protocol PersistanceManagerProtocol: AnyObject {
     var context: NSManagedObjectContext { get }
     var fingerprint: String { get }
     
-    func commitContext()
+    @discardableResult
+    func commitContext() -> Bool
     func reloadContainer()
     
     //MARK: - Fetching -
@@ -51,7 +52,8 @@ protocol PersistanceManagerProtocol: AnyObject {
     func updateFilter(_ filter: Filter, filterCase: FilterCase)
     func updateFilter(_ filter: Filter, filterTarget: FilterTarget)
     func updateFilter(_ filter: Filter, filterText: String)
-    func saveCache(with filterList: AutomaticFilterListsResponse)
+    @discardableResult
+    func saveCache(with filterList: AutomaticFilterListsResponse) -> Bool
     func isCacheStale(comparedTo newFilterList: AutomaticFilterListsResponse) -> Bool
     func selectedCountries(for rule: RuleType) -> [String]
     func setSelectedCountries(_ countries: [String], for rule: RuleType)

--- a/Simply Filter SMS/Framework Layer/Shared with Extension/AppPersistentCloudKitContainer.swift
+++ b/Simply Filter SMS/Framework Layer/Shared with Extension/AppPersistentCloudKitContainer.swift
@@ -8,14 +8,39 @@
 import CoreData
 
 class AppPersistentCloudKitContainer: NSPersistentCloudKitContainer, @unchecked Sendable  {
+    // All containers in a process share the model, avoiding ambiguous entity
+    // class registration when independent readers are repeatedly opened.
+    private static let sharedModel = NSManagedObjectModel.mergedModel(from: [Bundle(for: AppPersistentCloudKitContainer.self)])!
+
+    convenience init(name: String) {
+        self.init(name: name, managedObjectModel: Self.sharedModel)
+    }
+
     override class func defaultDirectoryURL() -> URL {
         guard let storeURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: kAppGroupContainer) else {
-            return URL(fileURLWithPath: NSTemporaryDirectory())
+            // Sentinel only; loadPersistentStores rejects this configuration.
+            return URL(fileURLWithPath: "/unavailable-app-group")
         }
         
         return storeURL.appendingPathComponent(kDatabaseFilename)
     }
     
+    static func sharedStoreURL() throws -> URL {
+        guard let directory = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: kAppGroupContainer) else {
+            throw NSError(domain: "AppGroupConfiguration", code: 1)
+        }
+        return directory.appendingPathComponent(kDatabaseFilename).appendingPathComponent("\(kAppWorkingDirectory).sqlite")
+    }
+
+    override func loadPersistentStores(completionHandler block: @escaping (NSPersistentStoreDescription, Error?) -> Void) {
+        if let description = persistentStoreDescriptions.first,
+           description.url?.path.hasPrefix("/unavailable-app-group") == true {
+            block(description, NSError(domain: "AppGroupConfiguration", code: 1))
+            return
+        }
+        super.loadPersistentStores(completionHandler: block)
+    }
+
     convenience init(name: String, isReadOnly: Bool) {
         self.init(name: name)
 

--- a/Simply Filter SMS/Framework Layer/Shared with Extension/Constants.swift
+++ b/Simply Filter SMS/Framework Layer/Shared with Extension/Constants.swift
@@ -19,7 +19,6 @@ let kSupportEmail = "grizz.apps.dev@gmail.com"
 let kUpdateAutomaticFiltersMinDays = 3
 let kMinimumFilterLength = 1
 let kHideiClouldStatusMemory = 60
-let kOwnedStoreLoadTimeout: TimeInterval = 3.0
 let kFilterExportFileExtension = "sfsfilters"
 let kFilterExportTypeIdentifier = "com.grizz.apps.dev.simply-filter-sms.filters"
 let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "#ERROR#"

--- a/Simply Filter SMS/Resources/ar.lproj/Localizable.strings
+++ b/Simply Filter SMS/Resources/ar.lproj/Localizable.strings
@@ -564,3 +564,14 @@
 "whatsNew_filterTransfer_desc" = "شارك فلاترك مع صديق - صدّر ملفًا من **أدوات المرشحات** في القائمة وأرسله.";
 "whatsNew_appearanceTouchup_title" = "لمسة على المظهر";
 "whatsNew_appearanceTouchup_desc" = "**مساعدة** و**اختبر مرشّحاتك** بمظهر جديد. يمكنك أيضاً اختيار **لون التمييز** من القائمة - تتبعه الأزرار والأيقونات.";
+
+// Saved-rule diagnostics: English fallback pending translation.
+"testFilters_savedTitle" = "Saved Rules Test";
+"testFilters_savedFooter" = "Tests saved rules using an independent reader. Enter the exact sender and message. This does not verify extension invocation, sender eligibility, or where iOS places a message, and does not reclassify old messages.";
+"testFilters_senderRequired" = "Enter the actual sender to test sender-dependent rules.";
+"testFilters_unavailable" = "Saved rules could not be evaluated. No classification is available.";
+"rules_saveFailedTitle" = "Rules could not be saved";
+"rules_saveFailedMessage" = "The latest changes were rolled back and are not active. Please try the edit again. Previously saved rules are unchanged.";
+
+"rules_loadFailedTitle" = "Saved rules are unavailable";
+"rules_loadFailedMessage" = "The shared rules store could not be opened. Filtering cannot be verified. Try reopening the app; if this continues, check the app installation and contact support.";

--- a/Simply Filter SMS/Resources/de.lproj/Localizable.strings
+++ b/Simply Filter SMS/Resources/de.lproj/Localizable.strings
@@ -564,3 +564,14 @@
 "whatsNew_filterTransfer_desc" = "Teile deine Filter mit einem Freund - exportiere eine Datei aus **Filter-Tools** im Menü und sende sie.";
 "whatsNew_appearanceTouchup_title" = "Optik-Feinschliff";
 "whatsNew_appearanceTouchup_desc" = "**Hilfe** und **Filter testen** haben ein neues Aussehen. Du kannst auch eine **Akzentfarbe** im Menü wählen - Schaltflächen und Symbole folgen ihr.";
+
+// Saved-rule diagnostics: English fallback pending translation.
+"testFilters_savedTitle" = "Saved Rules Test";
+"testFilters_savedFooter" = "Tests saved rules using an independent reader. Enter the exact sender and message. This does not verify extension invocation, sender eligibility, or where iOS places a message, and does not reclassify old messages.";
+"testFilters_senderRequired" = "Enter the actual sender to test sender-dependent rules.";
+"testFilters_unavailable" = "Saved rules could not be evaluated. No classification is available.";
+"rules_saveFailedTitle" = "Rules could not be saved";
+"rules_saveFailedMessage" = "The latest changes were rolled back and are not active. Please try the edit again. Previously saved rules are unchanged.";
+
+"rules_loadFailedTitle" = "Saved rules are unavailable";
+"rules_loadFailedMessage" = "The shared rules store could not be opened. Filtering cannot be verified. Try reopening the app; if this continues, check the app installation and contact support.";

--- a/Simply Filter SMS/Resources/en.lproj/Localizable.strings
+++ b/Simply Filter SMS/Resources/en.lproj/Localizable.strings
@@ -361,3 +361,13 @@
 "callingCode_+262" = "Réunion & Mayotte";
 "callingCode_+590" = "Guadeloupe";
 "callingCode_+599" = "Netherlands Antilles";
+
+"testFilters_savedTitle" = "Saved Rules Test";
+"testFilters_savedFooter" = "Tests saved rules using an independent reader. Enter the exact sender and message. This does not verify extension invocation, sender eligibility, or where iOS places a message, and does not reclassify old messages.";
+"testFilters_senderRequired" = "Enter the actual sender to test sender-dependent rules.";
+"testFilters_unavailable" = "Saved rules could not be evaluated. No classification is available.";
+"rules_saveFailedTitle" = "Rules could not be saved";
+"rules_saveFailedMessage" = "The latest changes were rolled back and are not active. Please try the edit again. Previously saved rules are unchanged.";
+
+"rules_loadFailedTitle" = "Saved rules are unavailable";
+"rules_loadFailedMessage" = "The shared rules store could not be opened. Filtering cannot be verified. Try reopening the app; if this continues, check the app installation and contact support.";

--- a/Simply Filter SMS/Resources/es.lproj/Localizable.strings
+++ b/Simply Filter SMS/Resources/es.lproj/Localizable.strings
@@ -564,3 +564,14 @@
 "whatsNew_filterTransfer_desc" = "Comparte tus filtros con un amigo - exporta un archivo desde **Herramientas de filtro** en el menú y envíalo.";
 "whatsNew_appearanceTouchup_title" = "Retoque de apariencia";
 "whatsNew_appearanceTouchup_desc" = "**Ayuda** y **Prueba tus filtros** tienen un aspecto nuevo. También puedes elegir un **Color de acento** en el menú - botones e iconos lo siguen.";
+
+// Saved-rule diagnostics: English fallback pending translation.
+"testFilters_savedTitle" = "Saved Rules Test";
+"testFilters_savedFooter" = "Tests saved rules using an independent reader. Enter the exact sender and message. This does not verify extension invocation, sender eligibility, or where iOS places a message, and does not reclassify old messages.";
+"testFilters_senderRequired" = "Enter the actual sender to test sender-dependent rules.";
+"testFilters_unavailable" = "Saved rules could not be evaluated. No classification is available.";
+"rules_saveFailedTitle" = "Rules could not be saved";
+"rules_saveFailedMessage" = "The latest changes were rolled back and are not active. Please try the edit again. Previously saved rules are unchanged.";
+
+"rules_loadFailedTitle" = "Saved rules are unavailable";
+"rules_loadFailedMessage" = "The shared rules store could not be opened. Filtering cannot be verified. Try reopening the app; if this continues, check the app installation and contact support.";

--- a/Simply Filter SMS/Resources/fr.lproj/Localizable.strings
+++ b/Simply Filter SMS/Resources/fr.lproj/Localizable.strings
@@ -564,3 +564,14 @@
 "whatsNew_filterTransfer_desc" = "Partage tes filtres avec un ami - exporte un fichier depuis **Outils de filtrage** dans le menu et envoie-le.";
 "whatsNew_appearanceTouchup_title" = "Retouche d'apparence";
 "whatsNew_appearanceTouchup_desc" = "**Aide** et **Tester tes filtres** ont un nouveau look. Tu peux aussi choisir une **Couleur d'accentuation** dans le menu - boutons et icônes la suivent.";
+
+// Saved-rule diagnostics: English fallback pending translation.
+"testFilters_savedTitle" = "Saved Rules Test";
+"testFilters_savedFooter" = "Tests saved rules using an independent reader. Enter the exact sender and message. This does not verify extension invocation, sender eligibility, or where iOS places a message, and does not reclassify old messages.";
+"testFilters_senderRequired" = "Enter the actual sender to test sender-dependent rules.";
+"testFilters_unavailable" = "Saved rules could not be evaluated. No classification is available.";
+"rules_saveFailedTitle" = "Rules could not be saved";
+"rules_saveFailedMessage" = "The latest changes were rolled back and are not active. Please try the edit again. Previously saved rules are unchanged.";
+
+"rules_loadFailedTitle" = "Saved rules are unavailable";
+"rules_loadFailedMessage" = "The shared rules store could not be opened. Filtering cannot be verified. Try reopening the app; if this continues, check the app installation and contact support.";

--- a/Simply Filter SMS/Resources/he.lproj/Localizable.strings
+++ b/Simply Filter SMS/Resources/he.lproj/Localizable.strings
@@ -564,3 +564,14 @@
 "whatsNew_filterTransfer_desc" = "שתפו את הפילטרים שלכם עם חברים - ייצאו קובץ מ**כלי פילטור** בתפריט ושלחו אותו.";
 "whatsNew_appearanceTouchup_title" = "ליטוש מראה";
 "whatsNew_appearanceTouchup_desc" = "ל**עזרה** ול**בחנו את הפילטרים שלכם** יש מראה חדש. אפשר גם לבחור **צבע הדגשה** מהתפריט - כפתורים וסמלים יתאימו אליו.";
+
+// Saved-rule diagnostics: English fallback pending translation.
+"testFilters_savedTitle" = "Saved Rules Test";
+"testFilters_savedFooter" = "Tests saved rules using an independent reader. Enter the exact sender and message. This does not verify extension invocation, sender eligibility, or where iOS places a message, and does not reclassify old messages.";
+"testFilters_senderRequired" = "Enter the actual sender to test sender-dependent rules.";
+"testFilters_unavailable" = "Saved rules could not be evaluated. No classification is available.";
+"rules_saveFailedTitle" = "Rules could not be saved";
+"rules_saveFailedMessage" = "The latest changes were rolled back and are not active. Please try the edit again. Previously saved rules are unchanged.";
+
+"rules_loadFailedTitle" = "Saved rules are unavailable";
+"rules_loadFailedMessage" = "The shared rules store could not be opened. Filtering cannot be verified. Try reopening the app; if this continues, check the app installation and contact support.";

--- a/Simply Filter SMS/Resources/it.lproj/Localizable.strings
+++ b/Simply Filter SMS/Resources/it.lproj/Localizable.strings
@@ -564,3 +564,14 @@
 "whatsNew_filterTransfer_desc" = "Condividi i tuoi filtri con un amico - esporta un file da **Strumenti filtro** nel menu e invialo.";
 "whatsNew_appearanceTouchup_title" = "Ritocco dell'aspetto";
 "whatsNew_appearanceTouchup_desc" = "**Aiuto** e **Testa i tuoi filtri** hanno un nuovo aspetto. Puoi anche scegliere un **Colore di accento** dal menu - pulsanti e icone lo seguono.";
+
+// Saved-rule diagnostics: English fallback pending translation.
+"testFilters_savedTitle" = "Saved Rules Test";
+"testFilters_savedFooter" = "Tests saved rules using an independent reader. Enter the exact sender and message. This does not verify extension invocation, sender eligibility, or where iOS places a message, and does not reclassify old messages.";
+"testFilters_senderRequired" = "Enter the actual sender to test sender-dependent rules.";
+"testFilters_unavailable" = "Saved rules could not be evaluated. No classification is available.";
+"rules_saveFailedTitle" = "Rules could not be saved";
+"rules_saveFailedMessage" = "The latest changes were rolled back and are not active. Please try the edit again. Previously saved rules are unchanged.";
+
+"rules_loadFailedTitle" = "Saved rules are unavailable";
+"rules_loadFailedMessage" = "The shared rules store could not be opened. Filtering cannot be verified. Try reopening the app; if this continues, check the app installation and contact support.";

--- a/Simply Filter SMS/Resources/ja.lproj/Localizable.strings
+++ b/Simply Filter SMS/Resources/ja.lproj/Localizable.strings
@@ -564,3 +564,14 @@
 "whatsNew_filterTransfer_desc" = "友だちとフィルタを共有 - メニューの**フィルタツール**からファイルを書き出して送信できます。";
 "whatsNew_appearanceTouchup_title" = "外観の仕上げ";
 "whatsNew_appearanceTouchup_desc" = "**ヘルプ**と**フィルターをテスト**のデザインを一新。メニューから**アクセントカラー**を選ぶと、ボタンとアイコンに反映されます。";
+
+// Saved-rule diagnostics: English fallback pending translation.
+"testFilters_savedTitle" = "Saved Rules Test";
+"testFilters_savedFooter" = "Tests saved rules using an independent reader. Enter the exact sender and message. This does not verify extension invocation, sender eligibility, or where iOS places a message, and does not reclassify old messages.";
+"testFilters_senderRequired" = "Enter the actual sender to test sender-dependent rules.";
+"testFilters_unavailable" = "Saved rules could not be evaluated. No classification is available.";
+"rules_saveFailedTitle" = "Rules could not be saved";
+"rules_saveFailedMessage" = "The latest changes were rolled back and are not active. Please try the edit again. Previously saved rules are unchanged.";
+
+"rules_loadFailedTitle" = "Saved rules are unavailable";
+"rules_loadFailedMessage" = "The shared rules store could not be opened. Filtering cannot be verified. Try reopening the app; if this continues, check the app installation and contact support.";

--- a/Simply Filter SMS/Resources/ko.lproj/Localizable.strings
+++ b/Simply Filter SMS/Resources/ko.lproj/Localizable.strings
@@ -564,3 +564,14 @@
 "whatsNew_filterTransfer_desc" = "친구와 필터를 공유하세요 - 메뉴의 **필터 도구**에서 파일을 내보낸 뒤 보내세요.";
 "whatsNew_appearanceTouchup_title" = "모양 다듬기";
 "whatsNew_appearanceTouchup_desc" = "**도움말**과 **필터 테스트**가 새 모습입니다. 메뉴에서 **강조 색상**을 고르면 버튼과 아이콘에 적용됩니다.";
+
+// Saved-rule diagnostics: English fallback pending translation.
+"testFilters_savedTitle" = "Saved Rules Test";
+"testFilters_savedFooter" = "Tests saved rules using an independent reader. Enter the exact sender and message. This does not verify extension invocation, sender eligibility, or where iOS places a message, and does not reclassify old messages.";
+"testFilters_senderRequired" = "Enter the actual sender to test sender-dependent rules.";
+"testFilters_unavailable" = "Saved rules could not be evaluated. No classification is available.";
+"rules_saveFailedTitle" = "Rules could not be saved";
+"rules_saveFailedMessage" = "The latest changes were rolled back and are not active. Please try the edit again. Previously saved rules are unchanged.";
+
+"rules_loadFailedTitle" = "Saved rules are unavailable";
+"rules_loadFailedMessage" = "The shared rules store could not be opened. Filtering cannot be verified. Try reopening the app; if this continues, check the app installation and contact support.";

--- a/Simply Filter SMS/Resources/pt-BR.lproj/Localizable.strings
+++ b/Simply Filter SMS/Resources/pt-BR.lproj/Localizable.strings
@@ -564,3 +564,14 @@
 "whatsNew_filterTransfer_desc" = "Compartilhe seus filtros com um amigo - exporte um arquivo em **Ferramentas de filtro** no menu e envie.";
 "whatsNew_appearanceTouchup_title" = "Retoque de aparência";
 "whatsNew_appearanceTouchup_desc" = "**Ajuda** e **Testar Seus Filtros** estão com visual novo. Você também pode escolher uma **Cor de destaque** no menu - botões e ícones a seguem.";
+
+// Saved-rule diagnostics: English fallback pending translation.
+"testFilters_savedTitle" = "Saved Rules Test";
+"testFilters_savedFooter" = "Tests saved rules using an independent reader. Enter the exact sender and message. This does not verify extension invocation, sender eligibility, or where iOS places a message, and does not reclassify old messages.";
+"testFilters_senderRequired" = "Enter the actual sender to test sender-dependent rules.";
+"testFilters_unavailable" = "Saved rules could not be evaluated. No classification is available.";
+"rules_saveFailedTitle" = "Rules could not be saved";
+"rules_saveFailedMessage" = "The latest changes were rolled back and are not active. Please try the edit again. Previously saved rules are unchanged.";
+
+"rules_loadFailedTitle" = "Saved rules are unavailable";
+"rules_loadFailedMessage" = "The shared rules store could not be opened. Filtering cannot be verified. Try reopening the app; if this continues, check the app installation and contact support.";

--- a/Simply Filter SMS/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Simply Filter SMS/Resources/zh-Hans.lproj/Localizable.strings
@@ -337,3 +337,14 @@
 "callingCode_+262" = "留尼汪和马约特";
 "callingCode_+590" = "瓜德罗普";
 "callingCode_+599" = "荷属安的列斯";
+
+// Saved-rule diagnostics: English fallback pending translation.
+"testFilters_savedTitle" = "Saved Rules Test";
+"testFilters_savedFooter" = "Tests saved rules using an independent reader. Enter the exact sender and message. This does not verify extension invocation, sender eligibility, or where iOS places a message, and does not reclassify old messages.";
+"testFilters_senderRequired" = "Enter the actual sender to test sender-dependent rules.";
+"testFilters_unavailable" = "Saved rules could not be evaluated. No classification is available.";
+"rules_saveFailedTitle" = "Rules could not be saved";
+"rules_saveFailedMessage" = "The latest changes were rolled back and are not active. Please try the edit again. Previously saved rules are unchanged.";
+
+"rules_loadFailedTitle" = "Saved rules are unavailable";
+"rules_loadFailedMessage" = "The shared rules store could not be opened. Filtering cannot be verified. Try reopening the app; if this continues, check the app installation and contact support.";

--- a/Simply Filter SMS/Services Layer/ReportMessageService.swift
+++ b/Simply Filter SMS/Services Layer/ReportMessageService.swift
@@ -18,10 +18,10 @@ class ReportMessageService: HTTPServiceBase, ReportMessageServiceProtocol {
     @discardableResult
     func reportMessage(reportMessageRequestBody: ReportMessageRequestBody) async -> Bool {
         guard self.networkSyncManager?.networkStatus == .online else {
-            AppManager.logger.debug("reportMessage — skipped (offline) | type: \(reportMessageRequestBody.type, privacy: .public) | sender: '\(reportMessageRequestBody.sender, privacy: .public)'")
+            AppManager.logger.debug("reportMessage — skipped (offline) | type: \(reportMessageRequestBody.type, privacy: .public)")
             return false
         }
-        AppManager.logger.debug("reportMessage — sending | type: \(reportMessageRequestBody.type, privacy: .public) | sender: '\(reportMessageRequestBody.sender, privacy: .public)'")
+        AppManager.logger.debug("reportMessage — sending | type: \(reportMessageRequestBody.type, privacy: .public)")
         do {
             let response = try await self.httpService.execute(type: ReportMessageResponse.self,
                                                               baseURL: .reportMessageURL,
@@ -30,7 +30,7 @@ class ReportMessageService: HTTPServiceBase, ReportMessageServiceProtocol {
             return response.statusCode == 200
         } catch (let error) {
             let nsError = error as NSError
-            AppManager.logger.error("ERROR! While reporting message: \(nsError), \(nsError.userInfo)")
+            AppManager.logger.error("ERROR! While reporting message: \(nsError.domain, privacy: .public) code=\(nsError.code, privacy: .public)")
         }
         return false
     }

--- a/Simply Filter SMS/Simply_Filter_SMSApp.swift
+++ b/Simply Filter SMS/Simply_Filter_SMSApp.swift
@@ -12,6 +12,8 @@ struct Simply_Filter_SMSApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     @StateObject private var homeModel = AppHomeView.ViewModel(appManager: AppManager.shared)
 
+    @StateObject private var saveState = RulesSaveState.shared
+
     init() {
         UIScrollView.appearance().delaysContentTouches = false
     }
@@ -20,6 +22,11 @@ struct Simply_Filter_SMSApp: App {
         WindowGroup {
             AppHomeView(model: homeModel)
                 .adaptiveLayoutEnvironment()
+                .alert(saveState.titleKey~, isPresented: $saveState.failed) {
+                    Button("OK", role: .cancel) { }
+                } message: {
+                    Text(saveState.messageKey~)
+                }
         }
     }
 }

--- a/Simply Filter SMS/View Layer/Others/FilterListRowView.swift
+++ b/Simply Filter SMS/View Layer/Others/FilterListRowView.swift
@@ -331,7 +331,6 @@ extension FilterListRowView {
         @discardableResult
         func updateFilter(filterText: String) -> Bool {
             let current = self.filter.text ?? ""
-            AppManager.logger.debug("FilterListRow.updateFilter(text) — proposed: '\(filterText, privacy: .public)', current: '\(current, privacy: .public)'")
 
             guard filterText != current else {
                 AppManager.logger.debug("FilterListRow.updateFilter(text) — skipped, unchanged")
@@ -356,6 +355,10 @@ extension FilterListRowView {
 
             AppManager.logger.debug("FilterListRow.updateFilter(text) — saving")
             self.appManager.persistanceManager.updateFilter(self.filter, filterText: filterText)
+            if self.filter.text != filterText {
+                self.text = self.filter.text ?? current
+                return true
+            }
             self.onUpdate?(false)
             return false
         }

--- a/Simply Filter SMS/View Layer/Others/TestFilterResultRow.swift
+++ b/Simply Filter SMS/View Layer/Others/TestFilterResultRow.swift
@@ -41,10 +41,10 @@ struct TestFilterResultRow: View {
         .accessibilityLabel(Self.accessibilityText(for: result))
     }
 
-    private var style: TestResultStyle { TestResultStyle(action: result.action) }
+    private var style: TestResultStyle { TestResultStyle(action: result.action, status: result.status) }
 
     static func accessibilityText(for result: MessageEvaluationResult) -> String {
-        let title = TestResultStyle(action: result.action).title
+        let title = TestResultStyle(action: result.action, status: result.status).title
         if let caption = result.match.caption {
             return "\(title). \(caption)"
         }
@@ -66,7 +66,13 @@ private struct TestResultStyle {
     let color: Color
     let icon: String
 
-    init(action: ILMessageFilterAction) {
+    init(action: ILMessageFilterAction, status: MessageEvaluationStatus) {
+        guard status == .success else {
+            self.title = "testFilters_unavailable"~
+            self.color = .secondary
+            self.icon = "exclamationmark.triangle"
+            return
+        }
         switch action {
         case .none, .allow:
             self.title = "testFilters_resultAllowed"~

--- a/Simply Filter SMS/View Layer/Screens/TestFiltersView.swift
+++ b/Simply Filter SMS/View Layer/Screens/TestFiltersView.swift
@@ -70,7 +70,11 @@ struct TestFiltersView: View {
                         .padding(.top, 15)
 
                         ZStack(alignment: .topLeading) {
-                            if let result = self.model.result {
+                            if self.model.sender.isEmpty && !self.model.text.isEmpty {
+                                Text("testFilters_senderRequired"~)
+                                    .font(.footnote)
+                                    .padding(20)
+                            } else if let result = self.model.result {
                                 TestFilterResultRow(result: result)
                                     .padding(.horizontal, 20)
                                     .padding(.top, 16)
@@ -85,7 +89,7 @@ struct TestFiltersView: View {
                     .padding(.horizontal, 16)
                     .padding(.top, 20)
 
-                    Text("testFilters_footer"~)
+                    Text("testFilters_savedFooter"~)
                         .font(.footnote)
                         .foregroundColor(.secondary)
                         .frame(maxWidth: .infinity, alignment: .leading)
@@ -106,7 +110,7 @@ struct TestFiltersView: View {
                     focusedField = .text
                 }
             }
-            .navigationTitle("testFilters_title"~)
+            .navigationTitle("testFilters_savedTitle"~)
             .toolbar {
                 ToolbarItem {
                     Button {
@@ -141,28 +145,27 @@ extension TestFiltersView {
         }
         @Published var result: MessageEvaluationResult?
         
-        private lazy var bodyOnlySender: String = {
-            let evaluator = self.appManager.messageEvaluationManager
-            let candidates = (0...9).map { String(repeating: String($0), count: 12) }
-            return candidates.first(where: { evaluator.evaluateMessage(body: "", sender: $0).action == .allow })
-                ?? candidates[0]
-        }()
-        
-        func updateResult() {
-            guard !self.text.isEmpty || !self.sender.isEmpty else {
-                if self.result != nil {
-                    self.result = nil
-                }
-                return
-            }
+        private let savedReader: MessageEvaluationManager
+        private var generation = 0
 
-            let next = self.appManager.messageEvaluationManager.evaluateMessage(
-                body: self.text,
-                sender: self.sender.isEmpty ? self.bodyOnlySender : self.sender
-            )
-            guard next != self.result else { return }
-            self.result = next
+        override init(appManager: AppManagerProtocol = AppManager.shared) {
+            savedReader = MessageEvaluationManager()
+            super.init(appManager: appManager)
         }
+
+        func updateResult() {
+            generation += 1
+            let requestGeneration = generation
+            result = nil
+            guard !sender.isEmpty else { return }
+            savedReader.evaluateMessage(body: text, sender: sender) { [weak self] next in
+                DispatchQueue.main.async {
+                    guard let self, self.generation == requestGeneration else { return }
+                    self.result = next
+                }
+            }
+        }
+
     }
 }
 

--- a/Tests/MessageEvaluationManagerTests.swift
+++ b/Tests/MessageEvaluationManagerTests.swift
@@ -600,3 +600,170 @@ class MessageEvaluationManagerTests: XCTestCase {
         try? self.testSubject.context.save()
     }
 }
+
+/// Independent SQLite containers exercise the same read-only path as the extension.
+final class SavedRulesReaderTests: XCTestCase {
+    private var directory: URL!
+    private var writers: [NSPersistentContainer] = []
+    private var url: URL { directory.appendingPathComponent("rules.sqlite") }
+
+    override func setUpWithError() throws {
+        directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        for writer in writers {
+            writer.viewContext.performAndWait { writer.viewContext.reset() }
+            for store in writer.persistentStoreCoordinator.persistentStores {
+                try writer.persistentStoreCoordinator.remove(store)
+            }
+        }
+        writers.removeAll()
+        try FileManager.default.removeItem(at: directory)
+    }
+
+    private func writer() throws -> NSPersistentContainer {
+        let container = AppPersistentCloudKitContainer(name: kAppWorkingDirectory)
+        let description = NSPersistentStoreDescription(url: url)
+        description.setOption(true as NSNumber, forKey: NSPersistentHistoryTrackingKey)
+        container.persistentStoreDescriptions = [description]
+        var failure: Error?
+        container.loadPersistentStores { _, error in failure = error }
+        if let failure { throw failure }
+        writers.append(container)
+        return container
+    }
+
+    private func add(_ context: NSManagedObjectContext, text: String, type: FilterType, target: FilterTarget) -> Filter {
+        let filter = Filter(context: context)
+        filter.uuid = UUID()
+        filter.text = text
+        filter.filterType = type
+        filter.filterTarget = target
+        filter.filterMatching = .contains
+        filter.filterCase = .caseInsensitive
+        filter.denyFolderType = .junk
+        return filter
+    }
+
+    func testCommittedParityPriorityAndFreshness() throws {
+        let writer = try writer()
+        let reader = MessageEvaluationManager(storeURL: url)
+        let secondReader = MessageEvaluationManager(storeURL: url)
+        try writer.viewContext.performAndWait {
+            let deny = add(writer.viewContext, text: "capital", type: .deny, target: .body)
+            let allow = add(writer.viewContext, text: "+15551111111", type: .allow, target: .sender)
+            try writer.viewContext.save()
+            XCTAssertEqual(reader.evaluateMessage(body: "capital", sender: "+15551111111").action, .allow)
+            let blocked = reader.evaluateMessage(body: "capital", sender: "+15552222222")
+            XCTAssertEqual(blocked.action, .junk)
+            XCTAssertEqual(blocked.status, .success)
+            XCTAssertEqual(blocked, secondReader.evaluateMessage(body: "capital", sender: "+15552222222"))
+            deny.text = "updated"
+            // An unsaved live edit must not affect the saved-rule reader.
+            XCTAssertEqual(reader.evaluateMessage(body: "capital", sender: "+15552222222").action, .junk)
+            deny.denyFolderType = .promotion
+            try writer.viewContext.save()
+            XCTAssertEqual(reader.evaluateMessage(body: "capital", sender: "+15552222222").match, .noMatch)
+            XCTAssertEqual(reader.evaluateMessage(body: "updated", sender: "+15552222222").action, .promotion)
+            deny.filterMatching = .regex
+            deny.text = "^updated$"
+            try writer.viewContext.save()
+            XCTAssertEqual(reader.evaluateMessage(body: "updated extra", sender: "+15552222222").action, .allow)
+            XCTAssertEqual(reader.evaluateMessage(body: "updated", sender: "+15552222222").action, .promotion)
+            writer.viewContext.delete(deny)
+            writer.viewContext.delete(allow)
+            try writer.viewContext.save()
+            XCTAssertEqual(reader.evaluateMessage(body: "updated", sender: "+15552222222").match, .noMatch)
+        }
+    }
+
+    func testMissingStoreRecoversAndConcurrentRequestsCompleteOnce() throws {
+        let reader = MessageEvaluationManager(storeURL: url)
+        let unavailable = reader.evaluateMessage(body: "capital", sender: "123456789")
+        XCTAssertEqual(unavailable.status, .storeUnavailable)
+        XCTAssertEqual(unavailable.action, .allow)
+        let writer = try writer()
+        try writer.viewContext.performAndWait {
+            _ = add(writer.viewContext, text: "capital", type: .deny, target: .body)
+            try writer.viewContext.save()
+        }
+        let completions = (0..<6).map { expectation(description: "query \($0)") }
+        for completion in completions {
+            completion.assertForOverFulfill = true
+            reader.evaluateMessage(body: "capital", sender: "123456789") { result in
+                XCTAssertEqual(result.action, .junk)
+                XCTAssertEqual(result.status, .success)
+                completion.fulfill()
+            }
+        }
+        wait(for: completions, timeout: 10)
+    }
+
+    func testMalformedCacheIsFailureRatherThanNoMatch() throws {
+        let writer = try writer()
+        try writer.viewContext.performAndWait {
+            let cache = AutomaticFiltersCache(context: writer.viewContext)
+            cache.filtersData = "not a valid cache"
+            try writer.viewContext.save()
+        }
+        let result = MessageEvaluationManager(storeURL: url).evaluateMessage(body: "hello", sender: "123456789")
+        XCTAssertEqual(result.status, .readFailed)
+        XCTAssertEqual(result.action, .allow)
+        XCTAssertNotEqual(result.match, .noMatch)
+        XCTAssertTrue(TestFilterResultRow.accessibilityText(for: result).contains("could not be evaluated"))
+    }
+
+    func testBlankSenderDoesNotProduceClassification() {
+        let model = TestFiltersView.ViewModel(appManager: mock_AppManager())
+        model.text = "capital"
+        XCTAssertNil(model.result)
+    }
+}
+
+private final class UnreadableRulesStore: NSIncrementalStore {
+    override func loadMetadata() throws {
+        metadata = [NSStoreTypeKey: NSStringFromClass(UnreadableRulesStore.self), NSStoreUUIDKey: UUID().uuidString]
+    }
+    override func execute(_ request: NSPersistentStoreRequest, with context: NSManagedObjectContext?) throws -> Any {
+        throw NSError(domain: "InjectedFetchFailure", code: 7)
+    }
+}
+
+extension SavedRulesReaderTests {
+    func testFetchFailureAndResponseMapping() throws {
+        NSPersistentStoreCoordinator.registerStoreClass(UnreadableRulesStore.self, forStoreType: NSStringFromClass(UnreadableRulesStore.self))
+        let model = AppPersistentCloudKitContainer(name: kAppWorkingDirectory).managedObjectModel
+        let coordinator = NSPersistentStoreCoordinator(managedObjectModel: model)
+        try coordinator.addPersistentStore(ofType: NSStringFromClass(UnreadableRulesStore.self), configurationName: nil, at: url)
+        let context = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
+        context.performAndWait { context.persistentStoreCoordinator = coordinator }
+        let result = MessageEvaluationManager(context: context).evaluateMessage(body: "hello", sender: "123456789")
+        XCTAssertEqual(result.status, .readFailed)
+        XCTAssertEqual(result.makeResponse().action, .allow)
+        XCTAssertEqual(MessageEvaluationResult(action: .junk).makeResponse().action, .junk)
+        XCTAssertEqual(MessageEvaluationResult(action: .allow).makeResponse().action, .allow)
+    }
+}
+
+extension SavedRulesReaderTests {
+    func testImportAndFailedSaveRemainConsistentWithReader() throws {
+        let manager = PersistanceManager(storeURL: url)
+        writers.append(manager.container)
+        let reader = MessageEvaluationManager(storeURL: url)
+        let importer = FilterTransferManager(persistanceManager: manager)
+        let result = importer.importFilters([
+            FilterTransferCandidate(text: "capital", type: .deny, denyFolder: .junk,
+                                    filterTarget: .body, filterMatching: .contains, filterCase: .caseInsensitive)
+        ])
+        XCTAssertEqual(result.added, 1)
+        XCTAssertEqual(reader.evaluateMessage(body: "capital", sender: "123456789").action, .junk)
+        let rule = try XCTUnwrap(manager.fetchFilterRecords().first)
+        manager.saveContext = { _ in throw NSError(domain: "InjectedSaveFailure", code: 2) }
+        manager.updateFilter(rule, filterText: "different")
+        XCTAssertEqual(rule.text, "capital")
+        XCTAssertEqual(reader.evaluateMessage(body: "capital", sender: "123456789").action, .junk)
+        XCTAssertEqual(reader.evaluateMessage(body: "different", sender: "123456789").match, .noMatch)
+    }
+}

--- a/Tests/Mocks/mock_PersistanceManager.swift
+++ b/Tests/Mocks/mock_PersistanceManager.swift
@@ -151,9 +151,11 @@ class mock_PersistanceManager: PersistanceManagerProtocol {
         return self.fetchFilterRecordsForTypeClosure?(filterType) ?? []
     }
     
-    func saveCache(with filterList: AutomaticFilterListsResponse) {
+    @discardableResult
+    func saveCache(with filterList: AutomaticFilterListsResponse) -> Bool {
         self.saveCacheCounter += 1
         self.saveCacheClosure?(filterList)
+        return true
     }
 
     func isCacheStale(comparedTo newFilterList: AutomaticFilterListsResponse) -> Bool {
@@ -161,9 +163,11 @@ class mock_PersistanceManager: PersistanceManagerProtocol {
         return self.isCacheStaleClosure?(newFilterList) ?? false
     }
     
-    func commitContext() {
+    @discardableResult
+    func commitContext() -> Bool {
         self.commitContextCounter += 1
         self.commitContextClosure?()
+        return true
     }
     
     func fetchAutomaticFiltersLanguageRecords() -> [AutomaticFiltersLanguage] {

--- a/Tests/PersistanceManagerTests.swift
+++ b/Tests/PersistanceManagerTests.swift
@@ -395,3 +395,24 @@ class PersistanceManagerTests: XCTestCase {
         self.saveNotificationCompleteHandler?(notification)
     }
 }
+
+extension PersistanceManagerTests {
+    func testFailedSaveRollsBackAndPublishesFailure() throws {
+        let manager = PersistanceManager(inMemory: true)
+        let failed = expectation(description: "visible save failure")
+        RulesSaveState.shared.failed = false
+        try manager.context.performAndWait {
+            let filter = Filter(context: manager.context)
+            filter.text = "draft"
+            manager.saveContext = { _ in throw NSError(domain: "InjectedSaveFailure", code: 1) }
+            XCTAssertFalse(manager.commitContext())
+            XCTAssertFalse(manager.context.hasChanges)
+        }
+        DispatchQueue.main.async {
+            XCTAssertTrue(RulesSaveState.shared.failed)
+            RulesSaveState.shared.failed = false
+            failed.fulfill()
+        }
+        wait(for: [failed], timeout: 3)
+    }
+}

--- a/docs/message-filter-routing-validation.md
+++ b/docs/message-filter-routing-validation.md
@@ -1,0 +1,68 @@
+# Saved-rule evaluation and iOS routing validation
+
+## Implemented behavior
+
+The tester now requires the actual sender and evaluates saved rules through the same independent read-only reader used by the Message Filter extension. It does not use the app's live edits. Clearing the sender clears the result, and results from obsolete asynchronous inputs cannot replace newer results.
+
+Each production query opens a read-only SQLite container on a serial worker queue, creates a private context, pins its query generation, evaluates on that context's queue, then resets the context and closes the store. Reopening on each query provides freshness and retries completed load failures without retaining a failed container. This trades some opening overhead for a small, explicit lifecycle; device latency remains to be measured. There is no invented IdentityLookup timeout.
+
+Load and read failures have separate statuses. Both retain the existing nonblocking `.allow` fallback; the tester presents them as unavailable, never as a successful Allow classification. Explicit allows, successful no-match, and failures remain distinguishable. Allow precedence, regex semantics, export format, and `.junk` mapping are unchanged.
+
+Failed app saves return failure, roll back pending context changes, and present an error. The user must repeat the failed edit. Failed mutations do not post success notifications; automatic cache update notifications require a successful save. Imports count only successfully added records. Imports remain a sequence of saves, not an atomic transaction: earlier successful additions can remain if a later save fails. Opening an unavailable App Group no longer silently substitutes a temporary rules database.
+
+Extension logs contain transient query IDs, version/build, result status, action, match category, and elapsed time. Error logs contain domain/code without userInfo or localized descriptions. Sender, body, and user rule text are excluded. The extension writes no shared diagnostic files and adds no network dependency. The unused example network manifest attributes were removed.
+
+New UI copy uses the existing Localizable.strings mechanism. Non-English localizations currently contain explicit English fallback copy for these new messages, pending translation.
+
+## Automated verification
+
+Run from the repository root, selecting an available simulator if this UUID is not present:
+
+```sh
+xcodebuild test \
+  -project 'Simply Filter SMS.xcodeproj' \
+  -scheme Tests \
+  -destination 'platform=iOS Simulator,id=C7F9D93D-B744-4A8B-9CFC-7645F2F1B148' \
+  -derivedDataPath /tmp/simplyfiltersms-build \
+  CODE_SIGNING_ALLOWED=NO
+
+xcodebuild build \
+  -project 'Simply Filter SMS.xcodeproj' \
+  -scheme 'Simply Filter SMS' \
+  -destination 'generic/platform=iOS' \
+  -derivedDataPath /tmp/simplyfiltersms-device-build \
+  CODE_SIGNING_ALLOWED=NO
+```
+
+The Tests scheme enables `-com.apple.CoreData.ConcurrencyDebug 1`. New tests cover independent SQLite reader parity; sender allow precedence; unsaved edits; committed text, folder, matching-mode changes and deletion; actual importer additions; failed save rollback and persisted parity; missing-store recovery; concurrent asynchronous completions; malformed cache and injected fetch failures; response action mapping; blank sender; and accessible error text. Existing tests exercise the remaining evaluation priority and regex behavior.
+
+Verified on September 5, 2026: all 112 unit/integration tests passed with zero failures, and the unsigned generic iOS device build succeeded. UI automation and real-device delivery were not run.
+
+Validation environment: Xcode 26.6 (17F113), iPhone 17 Pro simulator running iOS 26.5. Unsigned simulator execution intentionally cannot establish App Group entitlement access; integration tests inject temporary SQLite URLs. Unsigned device compilation also does not verify provisioning, signed entitlements, extension registration, locked-device access, or OS routing.
+
+## Real-device procedure
+
+1. Build and install the containing app and embedded extension using your normal development signing. Record app and extension version/build, iOS version/build, and whether the device was restarted/unlocked. On the built signed product, inspect both entitlements separately:
+
+   ```sh
+   codesign -d --entitlements :- '/absolute/path/to/Simply Filter SMS.app'
+   codesign -d --entitlements :- '/absolute/path/to/Simply Filter SMS.app/PlugIns/Message Filter Extension.appex'
+   ```
+
+   Substitute the actual archive/product paths and embedded `.appex` filename. Both should contain `group.com.grizz.apps.dev.simply-filter-sms`. Do not infer signed entitlements from source files or an unsigned build.
+
+2. Confirm Simply Filter SMS is selected in Messages' text-message filtering settings. Record Apple's Filter Spam and unknown-sender screening settings separately. Use an authorized test sender outside Contacts and established/replied-to conversations. Record transport (SMS, MMS, RCS, or iMessage). Do not send messages without authorization.
+
+3. Save a narrowly targeted test rule. Confirm no save error appears. Enter the exact sender and body in **Saved Rules Test**, and record its result. A test result does not establish sender eligibility or invoke the installed extension.
+
+4. In macOS Console, select the connected iPhone and start a verified live capture. Include info/debug messages and filter by subsystem `com.grizz.apps.dev.Simply-Filter-SMS`, category `extension`. Request a **new** incoming message from the authorized sender. Record query ID, version/build, status, action, match kind, elapsed time, and the actual Messages folder. Do not share raw message content unless intentionally supplied for investigation.
+
+5. Repeat after an extension cold start, with the containing app closed, after changing a saved rule, and after deleting/importing a rule. Compare each new delivery with an exact-input saved-rule test. Test the locked device after first unlock, and after reboot before first unlock where feasible; record accessibility failures without assuming that file protection caused them. Use iMessage as an ineligible control.
+
+6. If status is unavailable/readFailed, inspect error domain/code and investigate store/configuration access. If status is success and match is an explicit allow, inspect sender and rule precedence. If it is successful no-match, compare exact inputs and committed rules. If the extension records `.junk` but Messages shows Unknown Senders, retain that evidence and investigate OS behavior separately. A missing query log alone does not prove non-invocation unless capture coverage is established.
+
+These changes do not reclassify old messages. No device evidence has established a root cause for the three originally reported messages.
+
+## API references
+
+Apple's [IdentityLookup overview](https://developer.apple.com/documentation/identitylookup/sms-and-mms-message-filtering) documents the extension's inability to write shared containers or directly access the network. Its [Core Data background guide](https://developer.apple.com/documentation/coredata/using-core-data-in-the-background) describes queue confinement. The installed SDK retains `.junk` as the unwanted-message action. Apple's [iOS 26 filtering guide](https://support.apple.com/guide/iphone/screen-and-filter-texts-iph203ab0be4/26/ios/26) discusses text screening and filtering; it does not turn a local tester result into proof of delivery routing.


### PR DESCRIPTION
## Problem

The in-app filter tester could report Junk while an incoming message appeared under Unknown Senders in Messages.

The tester previously evaluated the containing app’s live Core Data context, while the Message Filter extension opened a separate read-only store. These paths could evaluate different rule states, particularly after a failed save. The tester also substituted a synthetic sender when the sender field was empty, which could bypass sender-dependent allowances or otherwise change matching behavior.

The investigation identified additional reliability and diagnostic gaps:

- Some store and fetch failures could appear as ordinary Allow results.
- Extension evaluation did not explicitly enforce Core Data queue confinement.
- The owned reader retained its container without an explicit recovery strategy after a completed load failure.
- App Group resolution silently fell back to a temporary directory.
- Save failures were logged without consistently preventing success notifications.
- Diagnostic logs included sender, message body, and rule text.

These are confirmed code paths, **not a proven explanation for the three reported messages**. Messages folder placement alone does not establish whether the extension ran, what action it returned, or how iOS handled that action.

## Changes

### Evaluate saved rules consistently

The tester now uses the same independent read-only reader implementation as the extension instead of the app’s live editing context.

Each production evaluation:

1. Opens the saved SQLite store on a serial worker queue.
2. Creates a private Core Data context.
3. Pins a query generation for a consistent evaluation.
4. Evaluates rules on the context’s queue.
5. Resets the context and closes the store.

Opening the store for each query provides committed-state freshness and retries failed opens on subsequent queries. This replaces the semaphore-based initialization flow without introducing an assumed IdentityLookup deadline.

### Make incomplete tests and failures explicit

The tester is labeled **Saved Rules Test** and requires the actual sender. It no longer fabricates a sender or displays a classification for a blank sender.

Asynchronous results from older inputs cannot replace results for newer inputs. The explanatory text clarifies that a saved-rule test does not verify extension invocation, sender eligibility, or final Messages folder placement.

Evaluation results now distinguish successful classification, unavailable storage, and read failures. Storage failures retain the existing nonblocking `.allow` fallback, but the tester displays an unavailable result rather than presenting that fallback as a successful Allow decision.

### Report persistence failures accurately

Save operations return a success/failure result. Failed saves roll back pending changes and display an error, requiring the user to repeat the edit.

Failed mutations no longer post success notifications. Automatic-cache update notifications require a successful save, and edited row text reflects rollback. Store-load failures are surfaced, and saves without an open persistent store are guarded to avoid a Core Data exception.

Missing App Group access no longer silently selects a temporary rules store.

### Improve diagnostics without exposing content

Extension diagnostics record a transient query ID, version/build, evaluation status, action, match category, and elapsed time. Failure diagnostics record error domain/code.

Sender, message body, and user rule text were removed from the affected operational logs. The extension does not write shared diagnostic files or add network access. Unused example network configuration was removed from its manifest.

## Preserved behavior

- Existing allow-before-deny precedence and evaluation order.
- `.junk` response mapping and folder actions.
- Existing matching and Swift Regex semantics.
- Import/export schema compatibility.
- Nonblocking behavior when rules cannot be evaluated.

## Validation

**All 112 unit and integration tests passed**, with Core Data concurrency checking enabled.

New coverage includes:

- Independent SQLite reader parity and sender allow precedence.
- Unsaved-edit isolation and committed-rule freshness.
- Text, folder, matching-mode changes, deletion, and imports.
- Failed-save rollback and persisted-reader consistency.
- Missing-store recovery and concurrent query completion.
- Injected fetch failures and malformed automatic-filter cache.
- Response action mapping, blank-sender behavior, and accessible error text.

The app and extensions also built successfully for a generic iOS device target with signing disabled.

## Limitations and follow-up

- Signed App Group entitlements, extension registration, locked-device accessibility, and actual Messages routing still require real-device validation.
- Per-query store opening adds overhead; device latency remains to be measured.
- Imports remain a sequence of saves, not an atomic transaction. Earlier successful additions may remain if a later save fails.
- New diagnostic UI strings have English fallback text in non-English localizations pending translation.
- These changes do not reclassify previously received messages.

`docs/message-filter-routing-validation.md` includes exact build/test commands, signed-entitlement checks, a device reproduction procedure, and guidance for interpreting extension logs alongside observed Messages placement.
